### PR TITLE
Swift code generation (part 2)

### DIFF
--- a/src/actions/normalize.js
+++ b/src/actions/normalize.js
@@ -78,19 +78,28 @@ const processTranslation = (language, value) => {
   }
   return {
     type: SINGULAR,
-    translation: value[language]
+    translation: value[language],
+    containsFormatting: isFormattingString(value[language])
   };
 };
 
 const processPlural = (plurals, language) => {
-  const pluralMap = Object.keys(plurals).reduce(
-    (result, key) => ({
+  let containsFormatting = false;
+  const pluralMap = Object.keys(plurals).reduce((result, key) => {
+    const translation = plurals[key][language];
+    containsFormatting = containsFormatting || isFormattingString(translation);
+    return {
       ...result,
-      [key]: plurals[key][language]
-    }),
-    {}
-  );
-  return { type: PLURAL, translation: pluralMap };
+      [key]: translation
+    };
+  }, {});
+  return {
+    type: PLURAL,
+    translation: pluralMap,
+    containsFormatting
+  };
 };
+
+const isFormattingString = string => string.includes("{{s}}") || string.includes("{{d}}");
 
 module.exports = { normalizeYaml, PLURAL, SINGULAR };

--- a/src/utils/fileUtils.js
+++ b/src/utils/fileUtils.js
@@ -17,7 +17,7 @@ const loadFile = filePath => {
   try {
     return Result.success(fs.readFileSync(filePath, "utf8"));
   } catch (error) {
-    return Result.error("Something went wrong.", error);
+    return Result.error(`Could not read file at path: ${filePath} .`, error);
   }
 };
 

--- a/src/utils/yamlUtils.js
+++ b/src/utils/yamlUtils.js
@@ -6,7 +6,7 @@ const loadYaml = filePath => {
   try {
     return Result.success(yaml.safeLoad(fs.readFileSync(filePath, "utf8")));
   } catch (error) {
-    return Result.error("Something went wrong.", error);
+    return Result.error(`Could not load YAML file at path: ${filePath}.`, error);
   }
 };
 

--- a/templates/code_generation_swift_child.hbs
+++ b/templates/code_generation_swift_child.hbs
@@ -1,28 +1,34 @@
-    {{#hasChildren}}
+{{#if hasChildren}}
     struct {{name}} {
-        {{#children}}
-        {{> child}}
-        {{/children}}
+{{#each children}}
+    {{> child}}
+{{/each}}
     }
-    {{/hasChildren}}
-    {{^hasChildren}}
-    {{#containsQuantity}}
+{{else}}
+{{#if containsQuantityAndFormatting}}
+    static func {{name}}(quantity: Int, args: CVarArg...) -> LocaliciousData {
+        let quantityType = LocaliciousQuantity(quanitity: quantity)
+        return LocaliciousData(
+{{else if containsQuantity}}
     static func {{name}}(quantity: Int) -> LocaliciousData {
         let quantityType = LocaliciousQuantity(quanitity: quantity)
         return LocaliciousData(
-    {{/containsQuantity}}
-    {{^containsQuantity}}
+{{else if containsFormatting}}
+    static func {{name}}(args: CVarArg...) -> LocaliciousData {
+        return LocaliciousData(
+{{else}}
     static let {{name}} = LocaliciousData(
-    {{/containsQuantity}}
-        {{#ACCESSIBILITY}}
+{{/if}}
+{{#ACCESSIBILITY}}
         accessibilityIdentifier: "{{../identifier}}",
-        accessibilityHintKey: {{#HINT}}"{{keyPath}}{{#../../containsQuantity}}.\(quantityType){{/../../containsQuantity}}"{{/HINT}}{{^HINT}}nil{{/HINT}},
-        accessibilityLabelKey: {{#LABEL}}"{{keyPath}}{{#../../containsQuantity}}.\(quantityType){{/../../containsQuantity}}"{{/LABEL}}{{^LABEL}}nil{{/LABEL}},
-        accessibilityValueKey: {{#VALUE}}"{{keyPath}}{{#../../containsQuantity}}.\(quantityType){{/../../containsQuantity}}"{{/VALUE}}{{^VALUE}}nil{{/VALUE}},
-        {{/ACCESSIBILITY}}
-        translationKey: {{#COPY}}"{{keyPath}}{{#../containsQuantity}}.\(quantityType){{/../containsQuantity}}"{{/COPY}}{{^COPY}}nil{{/COPY}}
+        accessibilityHintKey: {{#if HINT}}"{{HINT.keyPath}}{{#if ../containsQuantity}}.\(quantityType.rawValue){{/if}}"{{else}}nil{{/if}},
+        accessibilityLabelKey: {{#if LABEL}}"{{LABEL.keyPath}}{{#if ../containsQuantity}}.\(quantityType.rawValue){{/if}}"{{else}}nil{{/if}},
+        accessibilityValueKey: {{#if VALUE}}"{{VALUE.keyPath}}{{#if ../containsQuantity}}.\(quantityType.rawValue){{/if}}"{{else}}nil{{/if}},
+{{/ACCESSIBILITY}}
+        translationKey: {{#if COPY}}"{{COPY.keyPath}}{{#if containsQuantity}}.\(quantityType.rawValue){{/if}}"{{else}}nil{{/if}},
+        translationArgs: {{#if containsFormatting}}args{{else}}[]{{/if}}
     )
-    {{#containsQuantity}}
+{{#if requiresFunction}}
     }
-    {{/containsQuantity}}
-    {{/hasChildren}}
+{{/if}}
+{{/if}}

--- a/templates/code_generation_swift_file.hbs
+++ b/templates/code_generation_swift_file.hbs
@@ -1,10 +1,11 @@
 import UIKit
 
 protocol LocalisationProvider {
-    var translationKey: String? { get }
     var accessibilityHintKey: String? { get }
     var accessibilityLabelKey: String? { get }
     var accessibilityValueKey: String? { get }
+    var translationKey: String? { get }
+    var translationArgs: [CVarArg] { get }
 }
 
 struct LocaliciousData: LocalisationProvider {
@@ -13,6 +14,7 @@ struct LocaliciousData: LocalisationProvider {
     let accessibilityLabelKey: String?
     let accessibilityValueKey: String?
     let translationKey: String?
+    let translationArgs: [CVarArg]
 }
 
 enum LocaliciousQuantity: String {
@@ -50,7 +52,9 @@ extension LocalisationProvider {
     }
 
     private func translation(forKey key: String) -> String? {
-        return NSLocalizedString(key, comment: "")
+        let string = NSLocalizedString(key, comment: "")
+        guard translationArgs.count > 0 else { return string }
+        return String(format: string, translationArgs)
     }
 }
 

--- a/tests/actions/__snapshots__/normalize.test.js.snap
+++ b/tests/actions/__snapshots__/normalize.test.js.snap
@@ -4,6 +4,7 @@ exports[`normalizing works as expected with Android only 1`] = `
 Array [
   Object {
     "COPY": Object {
+      "containsFormatting": true,
       "translation": "Total price: %1{{s}}",
       "type": "SINGULAR",
     },
@@ -17,6 +18,7 @@ Array [
   },
   Object {
     "COPY": Object {
+      "containsFormatting": true,
       "translation": "Totaal: %1{{s}}",
       "type": "SINGULAR",
     },
@@ -30,6 +32,7 @@ Array [
   },
   Object {
     "COPY": Object {
+      "containsFormatting": true,
       "translation": "Total price before taxes: %1{{s}}",
       "type": "SINGULAR",
     },
@@ -43,6 +46,7 @@ Array [
   },
   Object {
     "COPY": Object {
+      "containsFormatting": true,
       "translation": "Subtotaal: %1{{s}}",
       "type": "SINGULAR",
     },
@@ -56,6 +60,7 @@ Array [
   },
   Object {
     "COPY": Object {
+      "containsFormatting": false,
       "translation": "We support nesting as deep as you like",
       "type": "SINGULAR",
     },
@@ -73,6 +78,7 @@ Array [
   },
   Object {
     "COPY": Object {
+      "containsFormatting": false,
       "translation": "Je kan zo veel lagen maken als je zelf wil",
       "type": "SINGULAR",
     },
@@ -90,6 +96,7 @@ Array [
   },
   Object {
     "COPY": Object {
+      "containsFormatting": true,
       "translation": "Help: %1{{s}}",
       "type": "SINGULAR",
     },
@@ -103,6 +110,7 @@ Array [
   },
   Object {
     "COPY": Object {
+      "containsFormatting": true,
       "translation": "Help %1{{s}}",
       "type": "SINGULAR",
     },
@@ -116,6 +124,7 @@ Array [
   },
   Object {
     "COPY": Object {
+      "containsFormatting": true,
       "translation": Object {
         "ONE": "%1{{d}} Pending order",
         "OTHER": "%1{{d}} Pending Orders",
@@ -133,6 +142,7 @@ Array [
   },
   Object {
     "COPY": Object {
+      "containsFormatting": true,
       "translation": Object {
         "ONE": "%1{{d}} Lopende bestelling",
         "OTHER": "%1{{d}} Lopende bestellingen",
@@ -150,6 +160,7 @@ Array [
   },
   Object {
     "COPY": Object {
+      "containsFormatting": false,
       "translation": "This > is a special <<Character>>",
       "type": "SINGULAR",
     },
@@ -163,6 +174,7 @@ Array [
   },
   Object {
     "COPY": Object {
+      "containsFormatting": false,
       "translation": "Dit > is een speciaal <<Karakter>>",
       "type": "SINGULAR",
     },
@@ -176,6 +188,7 @@ Array [
   },
   Object {
     "COPY": Object {
+      "containsFormatting": false,
       "translation": "This is a multiline string that may contain <a href=\\"about:blank\\">links</a>
 You better watch out!",
       "type": "SINGULAR",
@@ -190,6 +203,7 @@ You better watch out!",
   },
   Object {
     "COPY": Object {
+      "containsFormatting": false,
       "translation": "Dit is een string van meerdere regels die <a href=\\"about:blank\\">links</a> kan bevatten.
 Let maar eens op!",
       "type": "SINGULAR",
@@ -205,15 +219,18 @@ Let maar eens op!",
   Object {
     "ACCESSIBILITY": Object {
       "HINT": Object {
+        "containsFormatting": false,
         "translation": "This is the hint",
         "type": "SINGULAR",
       },
       "LABEL": Object {
+        "containsFormatting": false,
         "translation": "This is the label",
         "type": "SINGULAR",
       },
     },
     "COPY": Object {
+      "containsFormatting": false,
       "translation": "This is a component with accessiblity support",
       "type": "SINGULAR",
     },
@@ -227,15 +244,18 @@ Let maar eens op!",
   Object {
     "ACCESSIBILITY": Object {
       "HINT": Object {
+        "containsFormatting": false,
         "translation": "Dit is de hint",
         "type": "SINGULAR",
       },
       "LABEL": Object {
+        "containsFormatting": false,
         "translation": "Dit is de label",
         "type": "SINGULAR",
       },
     },
     "COPY": Object {
+      "containsFormatting": false,
       "translation": "Dit is een component met accessiblity support",
       "type": "SINGULAR",
     },
@@ -249,6 +269,7 @@ Let maar eens op!",
   Object {
     "ACCESSIBILITY": Object {
       "HINT": Object {
+        "containsFormatting": false,
         "translation": Object {
           "ONE": "The singular hint",
           "OTHER": "The plural hint",
@@ -256,6 +277,7 @@ Let maar eens op!",
         "type": "PLURAL",
       },
       "LABEL": Object {
+        "containsFormatting": false,
         "translation": Object {
           "ONE": "The singular label",
           "OTHER": "The plural label",
@@ -263,6 +285,7 @@ Let maar eens op!",
         "type": "PLURAL",
       },
       "VALUE": Object {
+        "containsFormatting": false,
         "translation": Object {
           "ONE": "The singular value",
           "OTHER": "The plural value",
@@ -272,6 +295,7 @@ Let maar eens op!",
       },
     },
     "COPY": Object {
+      "containsFormatting": false,
       "translation": Object {
         "ONE": "The singular copy",
         "OTHER": "The plural copy",
@@ -288,6 +312,7 @@ Let maar eens op!",
   Object {
     "ACCESSIBILITY": Object {
       "HINT": Object {
+        "containsFormatting": false,
         "translation": Object {
           "ONE": "De enkelvoudige hint",
           "OTHER": "De meervoudige hint",
@@ -295,6 +320,7 @@ Let maar eens op!",
         "type": "PLURAL",
       },
       "LABEL": Object {
+        "containsFormatting": false,
         "translation": Object {
           "ONE": "De enkelvoudige label",
           "OTHER": "De meervoudige label",
@@ -302,6 +328,7 @@ Let maar eens op!",
         "type": "PLURAL",
       },
       "VALUE": Object {
+        "containsFormatting": false,
         "translation": Object {
           "ONE": "De enkelvoudige waarde",
           "OTHER": "The meervoudige waarde",
@@ -311,6 +338,7 @@ Let maar eens op!",
       },
     },
     "COPY": Object {
+      "containsFormatting": false,
       "translation": Object {
         "ONE": "De enkelvoudige copy",
         "OTHER": "De meervoudige copy",
@@ -331,6 +359,7 @@ exports[`normalizing works as expected with all platforms 1`] = `
 Array [
   Object {
     "COPY": Object {
+      "containsFormatting": false,
       "translation": "Stay up to date",
       "type": "SINGULAR",
     },
@@ -344,6 +373,7 @@ Array [
   },
   Object {
     "COPY": Object {
+      "containsFormatting": false,
       "translation": "Blijf op de hoogte",
       "type": "SINGULAR",
     },
@@ -357,6 +387,7 @@ Array [
   },
   Object {
     "COPY": Object {
+      "containsFormatting": false,
       "translation": "Stay up to date",
       "type": "SINGULAR",
     },
@@ -370,6 +401,7 @@ Array [
   },
   Object {
     "COPY": Object {
+      "containsFormatting": false,
       "translation": "Blijf op de hoogte",
       "type": "SINGULAR",
     },
@@ -383,6 +415,7 @@ Array [
   },
   Object {
     "COPY": Object {
+      "containsFormatting": true,
       "translation": "Total price: %1{{s}}",
       "type": "SINGULAR",
     },
@@ -396,6 +429,7 @@ Array [
   },
   Object {
     "COPY": Object {
+      "containsFormatting": true,
       "translation": "Totaal: %1{{s}}",
       "type": "SINGULAR",
     },
@@ -409,6 +443,7 @@ Array [
   },
   Object {
     "COPY": Object {
+      "containsFormatting": true,
       "translation": "Total price before taxes: %1{{s}}",
       "type": "SINGULAR",
     },
@@ -422,6 +457,7 @@ Array [
   },
   Object {
     "COPY": Object {
+      "containsFormatting": true,
       "translation": "Subtotaal: %1{{s}}",
       "type": "SINGULAR",
     },
@@ -435,6 +471,7 @@ Array [
   },
   Object {
     "COPY": Object {
+      "containsFormatting": false,
       "translation": "We support nesting as deep as you like",
       "type": "SINGULAR",
     },
@@ -452,6 +489,7 @@ Array [
   },
   Object {
     "COPY": Object {
+      "containsFormatting": false,
       "translation": "Je kan zo veel lagen maken als je zelf wil",
       "type": "SINGULAR",
     },
@@ -469,6 +507,7 @@ Array [
   },
   Object {
     "COPY": Object {
+      "containsFormatting": true,
       "translation": "Help: %1{{s}}",
       "type": "SINGULAR",
     },
@@ -482,6 +521,7 @@ Array [
   },
   Object {
     "COPY": Object {
+      "containsFormatting": true,
       "translation": "Help %1{{s}}",
       "type": "SINGULAR",
     },
@@ -495,6 +535,7 @@ Array [
   },
   Object {
     "COPY": Object {
+      "containsFormatting": true,
       "translation": Object {
         "ONE": "%1{{d}} Pending order",
         "OTHER": "%1{{d}} Pending Orders",
@@ -512,6 +553,7 @@ Array [
   },
   Object {
     "COPY": Object {
+      "containsFormatting": true,
       "translation": Object {
         "ONE": "%1{{d}} Lopende bestelling",
         "OTHER": "%1{{d}} Lopende bestellingen",
@@ -529,6 +571,7 @@ Array [
   },
   Object {
     "COPY": Object {
+      "containsFormatting": false,
       "translation": "This > is a special <<Character>>",
       "type": "SINGULAR",
     },
@@ -542,6 +585,7 @@ Array [
   },
   Object {
     "COPY": Object {
+      "containsFormatting": false,
       "translation": "Dit > is een speciaal <<Karakter>>",
       "type": "SINGULAR",
     },
@@ -555,6 +599,7 @@ Array [
   },
   Object {
     "COPY": Object {
+      "containsFormatting": false,
       "translation": "This is a multiline string that may contain <a href=\\"about:blank\\">links</a>
 You better watch out!",
       "type": "SINGULAR",
@@ -569,6 +614,7 @@ You better watch out!",
   },
   Object {
     "COPY": Object {
+      "containsFormatting": false,
       "translation": "Dit is een string van meerdere regels die <a href=\\"about:blank\\">links</a> kan bevatten.
 Let maar eens op!",
       "type": "SINGULAR",
@@ -584,15 +630,18 @@ Let maar eens op!",
   Object {
     "ACCESSIBILITY": Object {
       "HINT": Object {
+        "containsFormatting": false,
         "translation": "This is the hint",
         "type": "SINGULAR",
       },
       "LABEL": Object {
+        "containsFormatting": false,
         "translation": "This is the label",
         "type": "SINGULAR",
       },
     },
     "COPY": Object {
+      "containsFormatting": false,
       "translation": "This is a component with accessiblity support",
       "type": "SINGULAR",
     },
@@ -606,15 +655,18 @@ Let maar eens op!",
   Object {
     "ACCESSIBILITY": Object {
       "HINT": Object {
+        "containsFormatting": false,
         "translation": "Dit is de hint",
         "type": "SINGULAR",
       },
       "LABEL": Object {
+        "containsFormatting": false,
         "translation": "Dit is de label",
         "type": "SINGULAR",
       },
     },
     "COPY": Object {
+      "containsFormatting": false,
       "translation": "Dit is een component met accessiblity support",
       "type": "SINGULAR",
     },
@@ -628,6 +680,7 @@ Let maar eens op!",
   Object {
     "ACCESSIBILITY": Object {
       "HINT": Object {
+        "containsFormatting": false,
         "translation": Object {
           "ONE": "The singular hint",
           "OTHER": "The plural hint",
@@ -635,6 +688,7 @@ Let maar eens op!",
         "type": "PLURAL",
       },
       "LABEL": Object {
+        "containsFormatting": false,
         "translation": Object {
           "ONE": "The singular label",
           "OTHER": "The plural label",
@@ -642,6 +696,7 @@ Let maar eens op!",
         "type": "PLURAL",
       },
       "VALUE": Object {
+        "containsFormatting": false,
         "translation": Object {
           "ONE": "The singular value",
           "OTHER": "The plural value",
@@ -651,6 +706,7 @@ Let maar eens op!",
       },
     },
     "COPY": Object {
+      "containsFormatting": false,
       "translation": Object {
         "ONE": "The singular copy",
         "OTHER": "The plural copy",
@@ -667,6 +723,7 @@ Let maar eens op!",
   Object {
     "ACCESSIBILITY": Object {
       "HINT": Object {
+        "containsFormatting": false,
         "translation": Object {
           "ONE": "De enkelvoudige hint",
           "OTHER": "De meervoudige hint",
@@ -674,6 +731,7 @@ Let maar eens op!",
         "type": "PLURAL",
       },
       "LABEL": Object {
+        "containsFormatting": false,
         "translation": Object {
           "ONE": "De enkelvoudige label",
           "OTHER": "De meervoudige label",
@@ -681,6 +739,7 @@ Let maar eens op!",
         "type": "PLURAL",
       },
       "VALUE": Object {
+        "containsFormatting": false,
         "translation": Object {
           "ONE": "De enkelvoudige waarde",
           "OTHER": "The meervoudige waarde",
@@ -690,6 +749,7 @@ Let maar eens op!",
       },
     },
     "COPY": Object {
+      "containsFormatting": false,
       "translation": Object {
         "ONE": "De enkelvoudige copy",
         "OTHER": "De meervoudige copy",
@@ -710,6 +770,7 @@ exports[`normalizing works as expected with iOS only 1`] = `
 Array [
   Object {
     "COPY": Object {
+      "containsFormatting": false,
       "translation": "Stay up to date",
       "type": "SINGULAR",
     },
@@ -723,6 +784,7 @@ Array [
   },
   Object {
     "COPY": Object {
+      "containsFormatting": false,
       "translation": "Blijf op de hoogte",
       "type": "SINGULAR",
     },
@@ -736,6 +798,7 @@ Array [
   },
   Object {
     "COPY": Object {
+      "containsFormatting": false,
       "translation": "Stay up to date",
       "type": "SINGULAR",
     },
@@ -749,6 +812,7 @@ Array [
   },
   Object {
     "COPY": Object {
+      "containsFormatting": false,
       "translation": "Blijf op de hoogte",
       "type": "SINGULAR",
     },
@@ -762,6 +826,7 @@ Array [
   },
   Object {
     "COPY": Object {
+      "containsFormatting": false,
       "translation": "We support nesting as deep as you like",
       "type": "SINGULAR",
     },
@@ -779,6 +844,7 @@ Array [
   },
   Object {
     "COPY": Object {
+      "containsFormatting": false,
       "translation": "Je kan zo veel lagen maken als je zelf wil",
       "type": "SINGULAR",
     },
@@ -796,6 +862,7 @@ Array [
   },
   Object {
     "COPY": Object {
+      "containsFormatting": true,
       "translation": "Help: %1{{s}}",
       "type": "SINGULAR",
     },
@@ -809,6 +876,7 @@ Array [
   },
   Object {
     "COPY": Object {
+      "containsFormatting": true,
       "translation": "Help %1{{s}}",
       "type": "SINGULAR",
     },
@@ -822,6 +890,7 @@ Array [
   },
   Object {
     "COPY": Object {
+      "containsFormatting": true,
       "translation": Object {
         "ONE": "%1{{d}} Pending order",
         "OTHER": "%1{{d}} Pending Orders",
@@ -839,6 +908,7 @@ Array [
   },
   Object {
     "COPY": Object {
+      "containsFormatting": true,
       "translation": Object {
         "ONE": "%1{{d}} Lopende bestelling",
         "OTHER": "%1{{d}} Lopende bestellingen",
@@ -856,6 +926,7 @@ Array [
   },
   Object {
     "COPY": Object {
+      "containsFormatting": false,
       "translation": "This > is a special <<Character>>",
       "type": "SINGULAR",
     },
@@ -869,6 +940,7 @@ Array [
   },
   Object {
     "COPY": Object {
+      "containsFormatting": false,
       "translation": "Dit > is een speciaal <<Karakter>>",
       "type": "SINGULAR",
     },
@@ -882,6 +954,7 @@ Array [
   },
   Object {
     "COPY": Object {
+      "containsFormatting": false,
       "translation": "This is a multiline string that may contain <a href=\\"about:blank\\">links</a>
 You better watch out!",
       "type": "SINGULAR",
@@ -896,6 +969,7 @@ You better watch out!",
   },
   Object {
     "COPY": Object {
+      "containsFormatting": false,
       "translation": "Dit is een string van meerdere regels die <a href=\\"about:blank\\">links</a> kan bevatten.
 Let maar eens op!",
       "type": "SINGULAR",
@@ -911,15 +985,18 @@ Let maar eens op!",
   Object {
     "ACCESSIBILITY": Object {
       "HINT": Object {
+        "containsFormatting": false,
         "translation": "This is the hint",
         "type": "SINGULAR",
       },
       "LABEL": Object {
+        "containsFormatting": false,
         "translation": "This is the label",
         "type": "SINGULAR",
       },
     },
     "COPY": Object {
+      "containsFormatting": false,
       "translation": "This is a component with accessiblity support",
       "type": "SINGULAR",
     },
@@ -933,15 +1010,18 @@ Let maar eens op!",
   Object {
     "ACCESSIBILITY": Object {
       "HINT": Object {
+        "containsFormatting": false,
         "translation": "Dit is de hint",
         "type": "SINGULAR",
       },
       "LABEL": Object {
+        "containsFormatting": false,
         "translation": "Dit is de label",
         "type": "SINGULAR",
       },
     },
     "COPY": Object {
+      "containsFormatting": false,
       "translation": "Dit is een component met accessiblity support",
       "type": "SINGULAR",
     },
@@ -955,6 +1035,7 @@ Let maar eens op!",
   Object {
     "ACCESSIBILITY": Object {
       "HINT": Object {
+        "containsFormatting": false,
         "translation": Object {
           "ONE": "The singular hint",
           "OTHER": "The plural hint",
@@ -962,6 +1043,7 @@ Let maar eens op!",
         "type": "PLURAL",
       },
       "LABEL": Object {
+        "containsFormatting": false,
         "translation": Object {
           "ONE": "The singular label",
           "OTHER": "The plural label",
@@ -969,6 +1051,7 @@ Let maar eens op!",
         "type": "PLURAL",
       },
       "VALUE": Object {
+        "containsFormatting": false,
         "translation": Object {
           "ONE": "The singular value",
           "OTHER": "The plural value",
@@ -978,6 +1061,7 @@ Let maar eens op!",
       },
     },
     "COPY": Object {
+      "containsFormatting": false,
       "translation": Object {
         "ONE": "The singular copy",
         "OTHER": "The plural copy",
@@ -994,6 +1078,7 @@ Let maar eens op!",
   Object {
     "ACCESSIBILITY": Object {
       "HINT": Object {
+        "containsFormatting": false,
         "translation": Object {
           "ONE": "De enkelvoudige hint",
           "OTHER": "De meervoudige hint",
@@ -1001,6 +1086,7 @@ Let maar eens op!",
         "type": "PLURAL",
       },
       "LABEL": Object {
+        "containsFormatting": false,
         "translation": Object {
           "ONE": "De enkelvoudige label",
           "OTHER": "De meervoudige label",
@@ -1008,6 +1094,7 @@ Let maar eens op!",
         "type": "PLURAL",
       },
       "VALUE": Object {
+        "containsFormatting": false,
         "translation": Object {
           "ONE": "De enkelvoudige waarde",
           "OTHER": "The meervoudige waarde",
@@ -1017,6 +1104,7 @@ Let maar eens op!",
       },
     },
     "COPY": Object {
+      "containsFormatting": false,
       "translation": Object {
         "ONE": "De enkelvoudige copy",
         "OTHER": "De meervoudige copy",

--- a/tests/actions/__snapshots__/render.test.js.snap
+++ b/tests/actions/__snapshots__/render.test.js.snap
@@ -72,10 +72,11 @@ You better watch out!</string>
       "data": "import UIKit
 
 protocol LocalisationProvider {
-    var translationKey: String? { get }
     var accessibilityHintKey: String? { get }
     var accessibilityLabelKey: String? { get }
     var accessibilityValueKey: String? { get }
+    var translationKey: String? { get }
+    var translationArgs: [CVarArg] { get }
 }
 
 struct LocaliciousData: LocalisationProvider {
@@ -84,6 +85,7 @@ struct LocaliciousData: LocalisationProvider {
     let accessibilityLabelKey: String?
     let accessibilityValueKey: String?
     let translationKey: String?
+    let translationArgs: [CVarArg]
 }
 
 enum LocaliciousQuantity: String {
@@ -121,7 +123,9 @@ extension LocalisationProvider {
     }
 
     private func translation(forKey key: String) -> String? {
-        return NSLocalizedString(key, comment: \\"\\")
+        let string = NSLocalizedString(key, comment: \\"\\")
+        guard translationArgs.count > 0 else { return string }
+        return String(format: string, translationArgs)
     }
 }
 
@@ -147,113 +151,130 @@ extension UILabel {
 
 struct L {
     struct Settings {
-            struct PushPermissionsRequest {
-                    static let Title = LocaliciousData(
-                        accessibilityIdentifier: \\"Settings.PushPermissionsRequest.Title\\",
-                        accessibilityHintKey: nil,
-                        accessibilityLabelKey: nil,
-                        accessibilityValueKey: nil,
-                        translationKey: \\"Settings.PushPermissionsRequest.Title.COPY\\"
-                    )
-                    static let Subtitle = LocaliciousData(
-                        accessibilityIdentifier: \\"Settings.PushPermissionsRequest.Subtitle\\",
-                        accessibilityHintKey: nil,
-                        accessibilityLabelKey: nil,
-                        accessibilityValueKey: nil,
-                        translationKey: \\"Settings.PushPermissionsRequest.Subtitle.COPY\\"
-                    )
-            }
+        struct PushPermissionsRequest {
+            static let Title = LocaliciousData(
+                accessibilityIdentifier: \\"Settings.PushPermissionsRequest.Title\\",
+                accessibilityHintKey: nil,
+                accessibilityLabelKey: nil,
+                accessibilityValueKey: nil,
+                translationKey: \\"Settings.PushPermissionsRequest.Title.COPY\\",
+                translationArgs: []
+            )
+            static let Subtitle = LocaliciousData(
+                accessibilityIdentifier: \\"Settings.PushPermissionsRequest.Subtitle\\",
+                accessibilityHintKey: nil,
+                accessibilityLabelKey: nil,
+                accessibilityValueKey: nil,
+                translationKey: \\"Settings.PushPermissionsRequest.Subtitle.COPY\\",
+                translationArgs: []
+            )
+        }
     }
     struct Checkout {
-            struct OrderOverview {
-                    static let Total = LocaliciousData(
-                        accessibilityIdentifier: \\"Checkout.OrderOverview.Total\\",
-                        accessibilityHintKey: nil,
-                        accessibilityLabelKey: nil,
-                        accessibilityValueKey: nil,
-                        translationKey: \\"Checkout.OrderOverview.Total.COPY\\"
-                    )
-                    static let Subtotal = LocaliciousData(
-                        accessibilityIdentifier: \\"Checkout.OrderOverview.Subtotal\\",
-                        accessibilityHintKey: nil,
-                        accessibilityLabelKey: nil,
-                        accessibilityValueKey: nil,
-                        translationKey: \\"Checkout.OrderOverview.Subtotal.COPY\\"
-                    )
+        struct OrderOverview {
+            static func Total(args: CVarArg...) -> LocaliciousData {
+                return LocaliciousData(
+                accessibilityIdentifier: \\"Checkout.OrderOverview.Total\\",
+                accessibilityHintKey: nil,
+                accessibilityLabelKey: nil,
+                accessibilityValueKey: nil,
+                translationKey: \\"Checkout.OrderOverview.Total.COPY\\",
+                translationArgs: args
+            )
             }
+            static func Subtotal(args: CVarArg...) -> LocaliciousData {
+                return LocaliciousData(
+                accessibilityIdentifier: \\"Checkout.OrderOverview.Subtotal\\",
+                accessibilityHintKey: nil,
+                accessibilityLabelKey: nil,
+                accessibilityValueKey: nil,
+                translationKey: \\"Checkout.OrderOverview.Subtotal.COPY\\",
+                translationArgs: args
+            )
+            }
+        }
     }
     struct Something {
-            struct With {
-                    struct An {
-                            struct Arbitrary {
-                                    struct Amount {
-                                            struct Of {
-                                                    static let Nesting = LocaliciousData(
-                                                        accessibilityIdentifier: \\"Something.With.An.Arbitrary.Amount.Of.Nesting\\",
-                                                        accessibilityHintKey: nil,
-                                                        accessibilityLabelKey: nil,
-                                                        accessibilityValueKey: nil,
-                                                        translationKey: \\"Something.With.An.Arbitrary.Amount.Of.Nesting.COPY\\"
-                                                    )
-                                            }
-                                    }
-                            }
+        struct With {
+            struct An {
+                struct Arbitrary {
+                    struct Amount {
+                        struct Of {
+                            static let Nesting = LocaliciousData(
+                                accessibilityIdentifier: \\"Something.With.An.Arbitrary.Amount.Of.Nesting\\",
+                                accessibilityHintKey: nil,
+                                accessibilityLabelKey: nil,
+                                accessibilityValueKey: nil,
+                                translationKey: \\"Something.With.An.Arbitrary.Amount.Of.Nesting.COPY\\",
+                                translationArgs: []
+                            )
+                        }
                     }
+                }
             }
+        }
     }
     struct Delivery {
-            struct Widget {
-                    static let Title = LocaliciousData(
-                        accessibilityIdentifier: \\"Delivery.Widget.Title\\",
-                        accessibilityHintKey: nil,
-                        accessibilityLabelKey: nil,
-                        accessibilityValueKey: nil,
-                        translationKey: \\"Delivery.Widget.Title.COPY\\"
-                    )
-                    static func SubTitle(quantity: Int) -> LocaliciousData {
-                        let quantityType = LocaliciousQuantity(quanitity: quantity)
-                        return LocaliciousData(
-                        accessibilityIdentifier: \\"Delivery.Widget.SubTitle\\",
-                        accessibilityHintKey: nil,
-                        accessibilityLabelKey: nil,
-                        accessibilityValueKey: nil,
-                        translationKey: \\"Delivery.Widget.SubTitle.COPY.\\\\(quantityType)\\"
-                    )
-                    }
-                    static let SpecialCharacters = LocaliciousData(
-                        accessibilityIdentifier: \\"Delivery.Widget.SpecialCharacters\\",
-                        accessibilityHintKey: nil,
-                        accessibilityLabelKey: nil,
-                        accessibilityValueKey: nil,
-                        translationKey: \\"Delivery.Widget.SpecialCharacters.COPY\\"
-                    )
-                    static let MultilineStrings = LocaliciousData(
-                        accessibilityIdentifier: \\"Delivery.Widget.MultilineStrings\\",
-                        accessibilityHintKey: nil,
-                        accessibilityLabelKey: nil,
-                        accessibilityValueKey: nil,
-                        translationKey: \\"Delivery.Widget.MultilineStrings.COPY\\"
-                    )
-            }
-    }
-    struct Accessible {
-            static let RegularComponent = LocaliciousData(
-                accessibilityIdentifier: \\"Accessible.RegularComponent\\",
-                accessibilityHintKey: \\"Accessible.RegularComponent.ACCESSIBILITY.HINT\\",
-                accessibilityLabelKey: \\"Accessible.RegularComponent.ACCESSIBILITY.LABEL\\",
+        struct Widget {
+            static func Title(args: CVarArg...) -> LocaliciousData {
+                return LocaliciousData(
+                accessibilityIdentifier: \\"Delivery.Widget.Title\\",
+                accessibilityHintKey: nil,
+                accessibilityLabelKey: nil,
                 accessibilityValueKey: nil,
-                translationKey: \\"Accessible.RegularComponent.COPY\\"
+                translationKey: \\"Delivery.Widget.Title.COPY\\",
+                translationArgs: args
             )
-            static func PluralComponent(quantity: Int) -> LocaliciousData {
+            }
+            static func SubTitle(quantity: Int, args: CVarArg...) -> LocaliciousData {
                 let quantityType = LocaliciousQuantity(quanitity: quantity)
                 return LocaliciousData(
-                accessibilityIdentifier: \\"Accessible.PluralComponent\\",
-                accessibilityHintKey: \\"Accessible.PluralComponent.ACCESSIBILITY.HINT.\\\\(quantityType)\\",
-                accessibilityLabelKey: \\"Accessible.PluralComponent.ACCESSIBILITY.LABEL.\\\\(quantityType)\\",
-                accessibilityValueKey: \\"Accessible.PluralComponent.ACCESSIBILITY.VALUE.\\\\(quantityType)\\",
-                translationKey: \\"Accessible.PluralComponent.COPY.\\\\(quantityType)\\"
+                accessibilityIdentifier: \\"Delivery.Widget.SubTitle\\",
+                accessibilityHintKey: nil,
+                accessibilityLabelKey: nil,
+                accessibilityValueKey: nil,
+                translationKey: \\"Delivery.Widget.SubTitle.COPY.\\\\(quantityType)\\",
+                translationArgs: args
             )
             }
+            static let SpecialCharacters = LocaliciousData(
+                accessibilityIdentifier: \\"Delivery.Widget.SpecialCharacters\\",
+                accessibilityHintKey: nil,
+                accessibilityLabelKey: nil,
+                accessibilityValueKey: nil,
+                translationKey: \\"Delivery.Widget.SpecialCharacters.COPY\\",
+                translationArgs: []
+            )
+            static let MultilineStrings = LocaliciousData(
+                accessibilityIdentifier: \\"Delivery.Widget.MultilineStrings\\",
+                accessibilityHintKey: nil,
+                accessibilityLabelKey: nil,
+                accessibilityValueKey: nil,
+                translationKey: \\"Delivery.Widget.MultilineStrings.COPY\\",
+                translationArgs: []
+            )
+        }
+    }
+    struct Accessible {
+        static let RegularComponent = LocaliciousData(
+            accessibilityIdentifier: \\"Accessible.RegularComponent\\",
+            accessibilityHintKey: \\"Accessible.RegularComponent.ACCESSIBILITY.HINT\\",
+            accessibilityLabelKey: \\"Accessible.RegularComponent.ACCESSIBILITY.LABEL\\",
+            accessibilityValueKey: nil,
+            translationKey: \\"Accessible.RegularComponent.COPY\\",
+            translationArgs: []
+        )
+        static func PluralComponent(quantity: Int) -> LocaliciousData {
+            let quantityType = LocaliciousQuantity(quanitity: quantity)
+            return LocaliciousData(
+            accessibilityIdentifier: \\"Accessible.PluralComponent\\",
+            accessibilityHintKey: \\"Accessible.PluralComponent.ACCESSIBILITY.HINT.\\\\(quantityType)\\",
+            accessibilityLabelKey: \\"Accessible.PluralComponent.ACCESSIBILITY.LABEL.\\\\(quantityType)\\",
+            accessibilityValueKey: \\"Accessible.PluralComponent.ACCESSIBILITY.VALUE.\\\\(quantityType)\\",
+            translationKey: \\"Accessible.PluralComponent.COPY.\\\\(quantityType)\\",
+            translationArgs: []
+        )
+        }
     }
 }",
       "path": ".//ios/Localizable.swift",
@@ -349,10 +370,11 @@ You better watch out!\\";
       "data": "import UIKit
 
 protocol LocalisationProvider {
-    var translationKey: String? { get }
     var accessibilityHintKey: String? { get }
     var accessibilityLabelKey: String? { get }
     var accessibilityValueKey: String? { get }
+    var translationKey: String? { get }
+    var translationArgs: [CVarArg] { get }
 }
 
 struct LocaliciousData: LocalisationProvider {
@@ -361,6 +383,7 @@ struct LocaliciousData: LocalisationProvider {
     let accessibilityLabelKey: String?
     let accessibilityValueKey: String?
     let translationKey: String?
+    let translationArgs: [CVarArg]
 }
 
 enum LocaliciousQuantity: String {
@@ -398,7 +421,9 @@ extension LocalisationProvider {
     }
 
     private func translation(forKey key: String) -> String? {
-        return NSLocalizedString(key, comment: \\"\\")
+        let string = NSLocalizedString(key, comment: \\"\\")
+        guard translationArgs.count > 0 else { return string }
+        return String(format: string, translationArgs)
     }
 }
 
@@ -424,95 +449,106 @@ extension UILabel {
 
 struct L {
     struct Settings {
-            struct PushPermissionsRequest {
-                    static let Title = LocaliciousData(
-                        accessibilityIdentifier: \\"Settings.PushPermissionsRequest.Title\\",
-                        accessibilityHintKey: nil,
-                        accessibilityLabelKey: nil,
-                        accessibilityValueKey: nil,
-                        translationKey: \\"Settings.PushPermissionsRequest.Title.COPY\\"
-                    )
-                    static let Subtitle = LocaliciousData(
-                        accessibilityIdentifier: \\"Settings.PushPermissionsRequest.Subtitle\\",
-                        accessibilityHintKey: nil,
-                        accessibilityLabelKey: nil,
-                        accessibilityValueKey: nil,
-                        translationKey: \\"Settings.PushPermissionsRequest.Subtitle.COPY\\"
-                    )
-            }
+        struct PushPermissionsRequest {
+            static let Title = LocaliciousData(
+                accessibilityIdentifier: \\"Settings.PushPermissionsRequest.Title\\",
+                accessibilityHintKey: nil,
+                accessibilityLabelKey: nil,
+                accessibilityValueKey: nil,
+                translationKey: \\"Settings.PushPermissionsRequest.Title.COPY\\",
+                translationArgs: []
+            )
+            static let Subtitle = LocaliciousData(
+                accessibilityIdentifier: \\"Settings.PushPermissionsRequest.Subtitle\\",
+                accessibilityHintKey: nil,
+                accessibilityLabelKey: nil,
+                accessibilityValueKey: nil,
+                translationKey: \\"Settings.PushPermissionsRequest.Subtitle.COPY\\",
+                translationArgs: []
+            )
+        }
     }
     struct Something {
-            struct With {
-                    struct An {
-                            struct Arbitrary {
-                                    struct Amount {
-                                            struct Of {
-                                                    static let Nesting = LocaliciousData(
-                                                        accessibilityIdentifier: \\"Something.With.An.Arbitrary.Amount.Of.Nesting\\",
-                                                        accessibilityHintKey: nil,
-                                                        accessibilityLabelKey: nil,
-                                                        accessibilityValueKey: nil,
-                                                        translationKey: \\"Something.With.An.Arbitrary.Amount.Of.Nesting.COPY\\"
-                                                    )
-                                            }
-                                    }
-                            }
+        struct With {
+            struct An {
+                struct Arbitrary {
+                    struct Amount {
+                        struct Of {
+                            static let Nesting = LocaliciousData(
+                                accessibilityIdentifier: \\"Something.With.An.Arbitrary.Amount.Of.Nesting\\",
+                                accessibilityHintKey: nil,
+                                accessibilityLabelKey: nil,
+                                accessibilityValueKey: nil,
+                                translationKey: \\"Something.With.An.Arbitrary.Amount.Of.Nesting.COPY\\",
+                                translationArgs: []
+                            )
+                        }
                     }
+                }
             }
+        }
     }
     struct Delivery {
-            struct Widget {
-                    static let Title = LocaliciousData(
-                        accessibilityIdentifier: \\"Delivery.Widget.Title\\",
-                        accessibilityHintKey: nil,
-                        accessibilityLabelKey: nil,
-                        accessibilityValueKey: nil,
-                        translationKey: \\"Delivery.Widget.Title.COPY\\"
-                    )
-                    static func SubTitle(quantity: Int) -> LocaliciousData {
-                        let quantityType = LocaliciousQuantity(quanitity: quantity)
-                        return LocaliciousData(
-                        accessibilityIdentifier: \\"Delivery.Widget.SubTitle\\",
-                        accessibilityHintKey: nil,
-                        accessibilityLabelKey: nil,
-                        accessibilityValueKey: nil,
-                        translationKey: \\"Delivery.Widget.SubTitle.COPY.\\\\(quantityType)\\"
-                    )
-                    }
-                    static let SpecialCharacters = LocaliciousData(
-                        accessibilityIdentifier: \\"Delivery.Widget.SpecialCharacters\\",
-                        accessibilityHintKey: nil,
-                        accessibilityLabelKey: nil,
-                        accessibilityValueKey: nil,
-                        translationKey: \\"Delivery.Widget.SpecialCharacters.COPY\\"
-                    )
-                    static let MultilineStrings = LocaliciousData(
-                        accessibilityIdentifier: \\"Delivery.Widget.MultilineStrings\\",
-                        accessibilityHintKey: nil,
-                        accessibilityLabelKey: nil,
-                        accessibilityValueKey: nil,
-                        translationKey: \\"Delivery.Widget.MultilineStrings.COPY\\"
-                    )
-            }
-    }
-    struct Accessible {
-            static let RegularComponent = LocaliciousData(
-                accessibilityIdentifier: \\"Accessible.RegularComponent\\",
-                accessibilityHintKey: \\"Accessible.RegularComponent.ACCESSIBILITY.HINT\\",
-                accessibilityLabelKey: \\"Accessible.RegularComponent.ACCESSIBILITY.LABEL\\",
+        struct Widget {
+            static func Title(args: CVarArg...) -> LocaliciousData {
+                return LocaliciousData(
+                accessibilityIdentifier: \\"Delivery.Widget.Title\\",
+                accessibilityHintKey: nil,
+                accessibilityLabelKey: nil,
                 accessibilityValueKey: nil,
-                translationKey: \\"Accessible.RegularComponent.COPY\\"
+                translationKey: \\"Delivery.Widget.Title.COPY\\",
+                translationArgs: args
             )
-            static func PluralComponent(quantity: Int) -> LocaliciousData {
+            }
+            static func SubTitle(quantity: Int, args: CVarArg...) -> LocaliciousData {
                 let quantityType = LocaliciousQuantity(quanitity: quantity)
                 return LocaliciousData(
-                accessibilityIdentifier: \\"Accessible.PluralComponent\\",
-                accessibilityHintKey: \\"Accessible.PluralComponent.ACCESSIBILITY.HINT.\\\\(quantityType)\\",
-                accessibilityLabelKey: \\"Accessible.PluralComponent.ACCESSIBILITY.LABEL.\\\\(quantityType)\\",
-                accessibilityValueKey: \\"Accessible.PluralComponent.ACCESSIBILITY.VALUE.\\\\(quantityType)\\",
-                translationKey: \\"Accessible.PluralComponent.COPY.\\\\(quantityType)\\"
+                accessibilityIdentifier: \\"Delivery.Widget.SubTitle\\",
+                accessibilityHintKey: nil,
+                accessibilityLabelKey: nil,
+                accessibilityValueKey: nil,
+                translationKey: \\"Delivery.Widget.SubTitle.COPY.\\\\(quantityType)\\",
+                translationArgs: args
             )
             }
+            static let SpecialCharacters = LocaliciousData(
+                accessibilityIdentifier: \\"Delivery.Widget.SpecialCharacters\\",
+                accessibilityHintKey: nil,
+                accessibilityLabelKey: nil,
+                accessibilityValueKey: nil,
+                translationKey: \\"Delivery.Widget.SpecialCharacters.COPY\\",
+                translationArgs: []
+            )
+            static let MultilineStrings = LocaliciousData(
+                accessibilityIdentifier: \\"Delivery.Widget.MultilineStrings\\",
+                accessibilityHintKey: nil,
+                accessibilityLabelKey: nil,
+                accessibilityValueKey: nil,
+                translationKey: \\"Delivery.Widget.MultilineStrings.COPY\\",
+                translationArgs: []
+            )
+        }
+    }
+    struct Accessible {
+        static let RegularComponent = LocaliciousData(
+            accessibilityIdentifier: \\"Accessible.RegularComponent\\",
+            accessibilityHintKey: \\"Accessible.RegularComponent.ACCESSIBILITY.HINT\\",
+            accessibilityLabelKey: \\"Accessible.RegularComponent.ACCESSIBILITY.LABEL\\",
+            accessibilityValueKey: nil,
+            translationKey: \\"Accessible.RegularComponent.COPY\\",
+            translationArgs: []
+        )
+        static func PluralComponent(quantity: Int) -> LocaliciousData {
+            let quantityType = LocaliciousQuantity(quanitity: quantity)
+            return LocaliciousData(
+            accessibilityIdentifier: \\"Accessible.PluralComponent\\",
+            accessibilityHintKey: \\"Accessible.PluralComponent.ACCESSIBILITY.HINT.\\\\(quantityType)\\",
+            accessibilityLabelKey: \\"Accessible.PluralComponent.ACCESSIBILITY.LABEL.\\\\(quantityType)\\",
+            accessibilityValueKey: \\"Accessible.PluralComponent.ACCESSIBILITY.VALUE.\\\\(quantityType)\\",
+            translationKey: \\"Accessible.PluralComponent.COPY.\\\\(quantityType)\\",
+            translationArgs: []
+        )
+        }
     }
 }",
       "path": ".//ios/Localizable.swift",
@@ -662,10 +698,11 @@ Let maar eens op!\\";
       "data": "import UIKit
 
 protocol LocalisationProvider {
-    var translationKey: String? { get }
     var accessibilityHintKey: String? { get }
     var accessibilityLabelKey: String? { get }
     var accessibilityValueKey: String? { get }
+    var translationKey: String? { get }
+    var translationArgs: [CVarArg] { get }
 }
 
 struct LocaliciousData: LocalisationProvider {
@@ -674,6 +711,7 @@ struct LocaliciousData: LocalisationProvider {
     let accessibilityLabelKey: String?
     let accessibilityValueKey: String?
     let translationKey: String?
+    let translationArgs: [CVarArg]
 }
 
 enum LocaliciousQuantity: String {
@@ -711,7 +749,9 @@ extension LocalisationProvider {
     }
 
     private func translation(forKey key: String) -> String? {
-        return NSLocalizedString(key, comment: \\"\\")
+        let string = NSLocalizedString(key, comment: \\"\\")
+        guard translationArgs.count > 0 else { return string }
+        return String(format: string, translationArgs)
     }
 }
 
@@ -737,196 +777,230 @@ extension UILabel {
 
 struct L {
     struct Checkout {
-            struct OrderOverview {
-                    static let Total = LocaliciousData(
-                        accessibilityIdentifier: \\"Checkout.OrderOverview.Total\\",
-                        accessibilityHintKey: nil,
-                        accessibilityLabelKey: nil,
-                        accessibilityValueKey: nil,
-                        translationKey: \\"Checkout.OrderOverview.Total.COPY\\"
-                    )
-                    static let Total = LocaliciousData(
-                        accessibilityIdentifier: \\"Checkout.OrderOverview.Total\\",
-                        accessibilityHintKey: nil,
-                        accessibilityLabelKey: nil,
-                        accessibilityValueKey: nil,
-                        translationKey: \\"Checkout.OrderOverview.Total.COPY\\"
-                    )
-                    static let Subtotal = LocaliciousData(
-                        accessibilityIdentifier: \\"Checkout.OrderOverview.Subtotal\\",
-                        accessibilityHintKey: nil,
-                        accessibilityLabelKey: nil,
-                        accessibilityValueKey: nil,
-                        translationKey: \\"Checkout.OrderOverview.Subtotal.COPY\\"
-                    )
-                    static let Subtotal = LocaliciousData(
-                        accessibilityIdentifier: \\"Checkout.OrderOverview.Subtotal\\",
-                        accessibilityHintKey: nil,
-                        accessibilityLabelKey: nil,
-                        accessibilityValueKey: nil,
-                        translationKey: \\"Checkout.OrderOverview.Subtotal.COPY\\"
-                    )
+        struct OrderOverview {
+            static func Total(args: CVarArg...) -> LocaliciousData {
+                return LocaliciousData(
+                accessibilityIdentifier: \\"Checkout.OrderOverview.Total\\",
+                accessibilityHintKey: nil,
+                accessibilityLabelKey: nil,
+                accessibilityValueKey: nil,
+                translationKey: \\"Checkout.OrderOverview.Total.COPY\\",
+                translationArgs: args
+            )
             }
+            static func Total(args: CVarArg...) -> LocaliciousData {
+                return LocaliciousData(
+                accessibilityIdentifier: \\"Checkout.OrderOverview.Total\\",
+                accessibilityHintKey: nil,
+                accessibilityLabelKey: nil,
+                accessibilityValueKey: nil,
+                translationKey: \\"Checkout.OrderOverview.Total.COPY\\",
+                translationArgs: args
+            )
+            }
+            static func Subtotal(args: CVarArg...) -> LocaliciousData {
+                return LocaliciousData(
+                accessibilityIdentifier: \\"Checkout.OrderOverview.Subtotal\\",
+                accessibilityHintKey: nil,
+                accessibilityLabelKey: nil,
+                accessibilityValueKey: nil,
+                translationKey: \\"Checkout.OrderOverview.Subtotal.COPY\\",
+                translationArgs: args
+            )
+            }
+            static func Subtotal(args: CVarArg...) -> LocaliciousData {
+                return LocaliciousData(
+                accessibilityIdentifier: \\"Checkout.OrderOverview.Subtotal\\",
+                accessibilityHintKey: nil,
+                accessibilityLabelKey: nil,
+                accessibilityValueKey: nil,
+                translationKey: \\"Checkout.OrderOverview.Subtotal.COPY\\",
+                translationArgs: args
+            )
+            }
+        }
     }
     struct Settings {
-            struct PushPermissionsRequest {
-                    static let Title = LocaliciousData(
-                        accessibilityIdentifier: \\"Settings.PushPermissionsRequest.Title\\",
-                        accessibilityHintKey: nil,
-                        accessibilityLabelKey: nil,
-                        accessibilityValueKey: nil,
-                        translationKey: \\"Settings.PushPermissionsRequest.Title.COPY\\"
-                    )
-                    static let Title = LocaliciousData(
-                        accessibilityIdentifier: \\"Settings.PushPermissionsRequest.Title\\",
-                        accessibilityHintKey: nil,
-                        accessibilityLabelKey: nil,
-                        accessibilityValueKey: nil,
-                        translationKey: \\"Settings.PushPermissionsRequest.Title.COPY\\"
-                    )
-                    static let Subtitle = LocaliciousData(
-                        accessibilityIdentifier: \\"Settings.PushPermissionsRequest.Subtitle\\",
-                        accessibilityHintKey: nil,
-                        accessibilityLabelKey: nil,
-                        accessibilityValueKey: nil,
-                        translationKey: \\"Settings.PushPermissionsRequest.Subtitle.COPY\\"
-                    )
-                    static let Subtitle = LocaliciousData(
-                        accessibilityIdentifier: \\"Settings.PushPermissionsRequest.Subtitle\\",
-                        accessibilityHintKey: nil,
-                        accessibilityLabelKey: nil,
-                        accessibilityValueKey: nil,
-                        translationKey: \\"Settings.PushPermissionsRequest.Subtitle.COPY\\"
-                    )
-            }
+        struct PushPermissionsRequest {
+            static let Title = LocaliciousData(
+                accessibilityIdentifier: \\"Settings.PushPermissionsRequest.Title\\",
+                accessibilityHintKey: nil,
+                accessibilityLabelKey: nil,
+                accessibilityValueKey: nil,
+                translationKey: \\"Settings.PushPermissionsRequest.Title.COPY\\",
+                translationArgs: []
+            )
+            static let Title = LocaliciousData(
+                accessibilityIdentifier: \\"Settings.PushPermissionsRequest.Title\\",
+                accessibilityHintKey: nil,
+                accessibilityLabelKey: nil,
+                accessibilityValueKey: nil,
+                translationKey: \\"Settings.PushPermissionsRequest.Title.COPY\\",
+                translationArgs: []
+            )
+            static let Subtitle = LocaliciousData(
+                accessibilityIdentifier: \\"Settings.PushPermissionsRequest.Subtitle\\",
+                accessibilityHintKey: nil,
+                accessibilityLabelKey: nil,
+                accessibilityValueKey: nil,
+                translationKey: \\"Settings.PushPermissionsRequest.Subtitle.COPY\\",
+                translationArgs: []
+            )
+            static let Subtitle = LocaliciousData(
+                accessibilityIdentifier: \\"Settings.PushPermissionsRequest.Subtitle\\",
+                accessibilityHintKey: nil,
+                accessibilityLabelKey: nil,
+                accessibilityValueKey: nil,
+                translationKey: \\"Settings.PushPermissionsRequest.Subtitle.COPY\\",
+                translationArgs: []
+            )
+        }
     }
     struct Something {
-            struct With {
-                    struct An {
-                            struct Arbitrary {
-                                    struct Amount {
-                                            struct Of {
-                                                    static let Nesting = LocaliciousData(
-                                                        accessibilityIdentifier: \\"Something.With.An.Arbitrary.Amount.Of.Nesting\\",
-                                                        accessibilityHintKey: nil,
-                                                        accessibilityLabelKey: nil,
-                                                        accessibilityValueKey: nil,
-                                                        translationKey: \\"Something.With.An.Arbitrary.Amount.Of.Nesting.COPY\\"
-                                                    )
-                                                    static let Nesting = LocaliciousData(
-                                                        accessibilityIdentifier: \\"Something.With.An.Arbitrary.Amount.Of.Nesting\\",
-                                                        accessibilityHintKey: nil,
-                                                        accessibilityLabelKey: nil,
-                                                        accessibilityValueKey: nil,
-                                                        translationKey: \\"Something.With.An.Arbitrary.Amount.Of.Nesting.COPY\\"
-                                                    )
-                                            }
-                                    }
-                            }
+        struct With {
+            struct An {
+                struct Arbitrary {
+                    struct Amount {
+                        struct Of {
+                            static let Nesting = LocaliciousData(
+                                accessibilityIdentifier: \\"Something.With.An.Arbitrary.Amount.Of.Nesting\\",
+                                accessibilityHintKey: nil,
+                                accessibilityLabelKey: nil,
+                                accessibilityValueKey: nil,
+                                translationKey: \\"Something.With.An.Arbitrary.Amount.Of.Nesting.COPY\\",
+                                translationArgs: []
+                            )
+                            static let Nesting = LocaliciousData(
+                                accessibilityIdentifier: \\"Something.With.An.Arbitrary.Amount.Of.Nesting\\",
+                                accessibilityHintKey: nil,
+                                accessibilityLabelKey: nil,
+                                accessibilityValueKey: nil,
+                                translationKey: \\"Something.With.An.Arbitrary.Amount.Of.Nesting.COPY\\",
+                                translationArgs: []
+                            )
+                        }
                     }
+                }
             }
+        }
     }
     struct Delivery {
-            struct Widget {
-                    static let Title = LocaliciousData(
-                        accessibilityIdentifier: \\"Delivery.Widget.Title\\",
-                        accessibilityHintKey: nil,
-                        accessibilityLabelKey: nil,
-                        accessibilityValueKey: nil,
-                        translationKey: \\"Delivery.Widget.Title.COPY\\"
-                    )
-                    static let Title = LocaliciousData(
-                        accessibilityIdentifier: \\"Delivery.Widget.Title\\",
-                        accessibilityHintKey: nil,
-                        accessibilityLabelKey: nil,
-                        accessibilityValueKey: nil,
-                        translationKey: \\"Delivery.Widget.Title.COPY\\"
-                    )
-                    static func SubTitle(quantity: Int) -> LocaliciousData {
-                        let quantityType = LocaliciousQuantity(quanitity: quantity)
-                        return LocaliciousData(
-                        accessibilityIdentifier: \\"Delivery.Widget.SubTitle\\",
-                        accessibilityHintKey: nil,
-                        accessibilityLabelKey: nil,
-                        accessibilityValueKey: nil,
-                        translationKey: \\"Delivery.Widget.SubTitle.COPY.\\\\(quantityType)\\"
-                    )
-                    }
-                    static func SubTitle(quantity: Int) -> LocaliciousData {
-                        let quantityType = LocaliciousQuantity(quanitity: quantity)
-                        return LocaliciousData(
-                        accessibilityIdentifier: \\"Delivery.Widget.SubTitle\\",
-                        accessibilityHintKey: nil,
-                        accessibilityLabelKey: nil,
-                        accessibilityValueKey: nil,
-                        translationKey: \\"Delivery.Widget.SubTitle.COPY.\\\\(quantityType)\\"
-                    )
-                    }
-                    static let SpecialCharacters = LocaliciousData(
-                        accessibilityIdentifier: \\"Delivery.Widget.SpecialCharacters\\",
-                        accessibilityHintKey: nil,
-                        accessibilityLabelKey: nil,
-                        accessibilityValueKey: nil,
-                        translationKey: \\"Delivery.Widget.SpecialCharacters.COPY\\"
-                    )
-                    static let SpecialCharacters = LocaliciousData(
-                        accessibilityIdentifier: \\"Delivery.Widget.SpecialCharacters\\",
-                        accessibilityHintKey: nil,
-                        accessibilityLabelKey: nil,
-                        accessibilityValueKey: nil,
-                        translationKey: \\"Delivery.Widget.SpecialCharacters.COPY\\"
-                    )
-                    static let MultilineStrings = LocaliciousData(
-                        accessibilityIdentifier: \\"Delivery.Widget.MultilineStrings\\",
-                        accessibilityHintKey: nil,
-                        accessibilityLabelKey: nil,
-                        accessibilityValueKey: nil,
-                        translationKey: \\"Delivery.Widget.MultilineStrings.COPY\\"
-                    )
-                    static let MultilineStrings = LocaliciousData(
-                        accessibilityIdentifier: \\"Delivery.Widget.MultilineStrings\\",
-                        accessibilityHintKey: nil,
-                        accessibilityLabelKey: nil,
-                        accessibilityValueKey: nil,
-                        translationKey: \\"Delivery.Widget.MultilineStrings.COPY\\"
-                    )
+        struct Widget {
+            static func Title(args: CVarArg...) -> LocaliciousData {
+                return LocaliciousData(
+                accessibilityIdentifier: \\"Delivery.Widget.Title\\",
+                accessibilityHintKey: nil,
+                accessibilityLabelKey: nil,
+                accessibilityValueKey: nil,
+                translationKey: \\"Delivery.Widget.Title.COPY\\",
+                translationArgs: args
+            )
             }
+            static func Title(args: CVarArg...) -> LocaliciousData {
+                return LocaliciousData(
+                accessibilityIdentifier: \\"Delivery.Widget.Title\\",
+                accessibilityHintKey: nil,
+                accessibilityLabelKey: nil,
+                accessibilityValueKey: nil,
+                translationKey: \\"Delivery.Widget.Title.COPY\\",
+                translationArgs: args
+            )
+            }
+            static func SubTitle(quantity: Int, args: CVarArg...) -> LocaliciousData {
+                let quantityType = LocaliciousQuantity(quanitity: quantity)
+                return LocaliciousData(
+                accessibilityIdentifier: \\"Delivery.Widget.SubTitle\\",
+                accessibilityHintKey: nil,
+                accessibilityLabelKey: nil,
+                accessibilityValueKey: nil,
+                translationKey: \\"Delivery.Widget.SubTitle.COPY.\\\\(quantityType)\\",
+                translationArgs: args
+            )
+            }
+            static func SubTitle(quantity: Int, args: CVarArg...) -> LocaliciousData {
+                let quantityType = LocaliciousQuantity(quanitity: quantity)
+                return LocaliciousData(
+                accessibilityIdentifier: \\"Delivery.Widget.SubTitle\\",
+                accessibilityHintKey: nil,
+                accessibilityLabelKey: nil,
+                accessibilityValueKey: nil,
+                translationKey: \\"Delivery.Widget.SubTitle.COPY.\\\\(quantityType)\\",
+                translationArgs: args
+            )
+            }
+            static let SpecialCharacters = LocaliciousData(
+                accessibilityIdentifier: \\"Delivery.Widget.SpecialCharacters\\",
+                accessibilityHintKey: nil,
+                accessibilityLabelKey: nil,
+                accessibilityValueKey: nil,
+                translationKey: \\"Delivery.Widget.SpecialCharacters.COPY\\",
+                translationArgs: []
+            )
+            static let SpecialCharacters = LocaliciousData(
+                accessibilityIdentifier: \\"Delivery.Widget.SpecialCharacters\\",
+                accessibilityHintKey: nil,
+                accessibilityLabelKey: nil,
+                accessibilityValueKey: nil,
+                translationKey: \\"Delivery.Widget.SpecialCharacters.COPY\\",
+                translationArgs: []
+            )
+            static let MultilineStrings = LocaliciousData(
+                accessibilityIdentifier: \\"Delivery.Widget.MultilineStrings\\",
+                accessibilityHintKey: nil,
+                accessibilityLabelKey: nil,
+                accessibilityValueKey: nil,
+                translationKey: \\"Delivery.Widget.MultilineStrings.COPY\\",
+                translationArgs: []
+            )
+            static let MultilineStrings = LocaliciousData(
+                accessibilityIdentifier: \\"Delivery.Widget.MultilineStrings\\",
+                accessibilityHintKey: nil,
+                accessibilityLabelKey: nil,
+                accessibilityValueKey: nil,
+                translationKey: \\"Delivery.Widget.MultilineStrings.COPY\\",
+                translationArgs: []
+            )
+        }
     }
     struct Accessible {
-            static let RegularComponent = LocaliciousData(
-                accessibilityIdentifier: \\"Accessible.RegularComponent\\",
-                accessibilityHintKey: \\"Accessible.RegularComponent.ACCESSIBILITY.HINT\\",
-                accessibilityLabelKey: \\"Accessible.RegularComponent.ACCESSIBILITY.LABEL\\",
-                accessibilityValueKey: nil,
-                translationKey: \\"Accessible.RegularComponent.COPY\\"
-            )
-            static let RegularComponent = LocaliciousData(
-                accessibilityIdentifier: \\"Accessible.RegularComponent\\",
-                accessibilityHintKey: \\"Accessible.RegularComponent.ACCESSIBILITY.HINT\\",
-                accessibilityLabelKey: \\"Accessible.RegularComponent.ACCESSIBILITY.LABEL\\",
-                accessibilityValueKey: nil,
-                translationKey: \\"Accessible.RegularComponent.COPY\\"
-            )
-            static func PluralComponent(quantity: Int) -> LocaliciousData {
-                let quantityType = LocaliciousQuantity(quanitity: quantity)
-                return LocaliciousData(
-                accessibilityIdentifier: \\"Accessible.PluralComponent\\",
-                accessibilityHintKey: \\"Accessible.PluralComponent.ACCESSIBILITY.HINT.\\\\(quantityType)\\",
-                accessibilityLabelKey: \\"Accessible.PluralComponent.ACCESSIBILITY.LABEL.\\\\(quantityType)\\",
-                accessibilityValueKey: \\"Accessible.PluralComponent.ACCESSIBILITY.VALUE.\\\\(quantityType)\\",
-                translationKey: \\"Accessible.PluralComponent.COPY.\\\\(quantityType)\\"
-            )
-            }
-            static func PluralComponent(quantity: Int) -> LocaliciousData {
-                let quantityType = LocaliciousQuantity(quanitity: quantity)
-                return LocaliciousData(
-                accessibilityIdentifier: \\"Accessible.PluralComponent\\",
-                accessibilityHintKey: \\"Accessible.PluralComponent.ACCESSIBILITY.HINT.\\\\(quantityType)\\",
-                accessibilityLabelKey: \\"Accessible.PluralComponent.ACCESSIBILITY.LABEL.\\\\(quantityType)\\",
-                accessibilityValueKey: \\"Accessible.PluralComponent.ACCESSIBILITY.VALUE.\\\\(quantityType)\\",
-                translationKey: \\"Accessible.PluralComponent.COPY.\\\\(quantityType)\\"
-            )
-            }
+        static let RegularComponent = LocaliciousData(
+            accessibilityIdentifier: \\"Accessible.RegularComponent\\",
+            accessibilityHintKey: \\"Accessible.RegularComponent.ACCESSIBILITY.HINT\\",
+            accessibilityLabelKey: \\"Accessible.RegularComponent.ACCESSIBILITY.LABEL\\",
+            accessibilityValueKey: nil,
+            translationKey: \\"Accessible.RegularComponent.COPY\\",
+            translationArgs: []
+        )
+        static let RegularComponent = LocaliciousData(
+            accessibilityIdentifier: \\"Accessible.RegularComponent\\",
+            accessibilityHintKey: \\"Accessible.RegularComponent.ACCESSIBILITY.HINT\\",
+            accessibilityLabelKey: \\"Accessible.RegularComponent.ACCESSIBILITY.LABEL\\",
+            accessibilityValueKey: nil,
+            translationKey: \\"Accessible.RegularComponent.COPY\\",
+            translationArgs: []
+        )
+        static func PluralComponent(quantity: Int) -> LocaliciousData {
+            let quantityType = LocaliciousQuantity(quanitity: quantity)
+            return LocaliciousData(
+            accessibilityIdentifier: \\"Accessible.PluralComponent\\",
+            accessibilityHintKey: \\"Accessible.PluralComponent.ACCESSIBILITY.HINT.\\\\(quantityType)\\",
+            accessibilityLabelKey: \\"Accessible.PluralComponent.ACCESSIBILITY.LABEL.\\\\(quantityType)\\",
+            accessibilityValueKey: \\"Accessible.PluralComponent.ACCESSIBILITY.VALUE.\\\\(quantityType)\\",
+            translationKey: \\"Accessible.PluralComponent.COPY.\\\\(quantityType)\\",
+            translationArgs: []
+        )
+        }
+        static func PluralComponent(quantity: Int) -> LocaliciousData {
+            let quantityType = LocaliciousQuantity(quanitity: quantity)
+            return LocaliciousData(
+            accessibilityIdentifier: \\"Accessible.PluralComponent\\",
+            accessibilityHintKey: \\"Accessible.PluralComponent.ACCESSIBILITY.HINT.\\\\(quantityType)\\",
+            accessibilityLabelKey: \\"Accessible.PluralComponent.ACCESSIBILITY.LABEL.\\\\(quantityType)\\",
+            accessibilityValueKey: \\"Accessible.PluralComponent.ACCESSIBILITY.VALUE.\\\\(quantityType)\\",
+            translationKey: \\"Accessible.PluralComponent.COPY.\\\\(quantityType)\\",
+            translationArgs: []
+        )
+        }
     }
 }",
       "path": ".//ios/Localizable.swift",
@@ -1068,10 +1142,11 @@ Let maar eens op!\\";
       "data": "import UIKit
 
 protocol LocalisationProvider {
-    var translationKey: String? { get }
     var accessibilityHintKey: String? { get }
     var accessibilityLabelKey: String? { get }
     var accessibilityValueKey: String? { get }
+    var translationKey: String? { get }
+    var translationArgs: [CVarArg] { get }
 }
 
 struct LocaliciousData: LocalisationProvider {
@@ -1080,6 +1155,7 @@ struct LocaliciousData: LocalisationProvider {
     let accessibilityLabelKey: String?
     let accessibilityValueKey: String?
     let translationKey: String?
+    let translationArgs: [CVarArg]
 }
 
 enum LocaliciousQuantity: String {
@@ -1117,7 +1193,9 @@ extension LocalisationProvider {
     }
 
     private func translation(forKey key: String) -> String? {
-        return NSLocalizedString(key, comment: \\"\\")
+        let string = NSLocalizedString(key, comment: \\"\\")
+        guard translationArgs.count > 0 else { return string }
+        return String(format: string, translationArgs)
     }
 }
 
@@ -1143,132 +1221,150 @@ extension UILabel {
 
 struct L {
     struct Something {
-            struct With {
-                    struct An {
-                            struct Arbitrary {
-                                    struct Amount {
-                                            struct Of {
-                                                    static let Nesting = LocaliciousData(
-                                                        accessibilityIdentifier: \\"Something.With.An.Arbitrary.Amount.Of.Nesting\\",
-                                                        accessibilityHintKey: nil,
-                                                        accessibilityLabelKey: nil,
-                                                        accessibilityValueKey: nil,
-                                                        translationKey: \\"Something.With.An.Arbitrary.Amount.Of.Nesting.COPY\\"
-                                                    )
-                                                    static let Nesting = LocaliciousData(
-                                                        accessibilityIdentifier: \\"Something.With.An.Arbitrary.Amount.Of.Nesting\\",
-                                                        accessibilityHintKey: nil,
-                                                        accessibilityLabelKey: nil,
-                                                        accessibilityValueKey: nil,
-                                                        translationKey: \\"Something.With.An.Arbitrary.Amount.Of.Nesting.COPY\\"
-                                                    )
-                                            }
-                                    }
-                            }
+        struct With {
+            struct An {
+                struct Arbitrary {
+                    struct Amount {
+                        struct Of {
+                            static let Nesting = LocaliciousData(
+                                accessibilityIdentifier: \\"Something.With.An.Arbitrary.Amount.Of.Nesting\\",
+                                accessibilityHintKey: nil,
+                                accessibilityLabelKey: nil,
+                                accessibilityValueKey: nil,
+                                translationKey: \\"Something.With.An.Arbitrary.Amount.Of.Nesting.COPY\\",
+                                translationArgs: []
+                            )
+                            static let Nesting = LocaliciousData(
+                                accessibilityIdentifier: \\"Something.With.An.Arbitrary.Amount.Of.Nesting\\",
+                                accessibilityHintKey: nil,
+                                accessibilityLabelKey: nil,
+                                accessibilityValueKey: nil,
+                                translationKey: \\"Something.With.An.Arbitrary.Amount.Of.Nesting.COPY\\",
+                                translationArgs: []
+                            )
+                        }
                     }
+                }
             }
+        }
     }
     struct Delivery {
-            struct Widget {
-                    static let Title = LocaliciousData(
-                        accessibilityIdentifier: \\"Delivery.Widget.Title\\",
-                        accessibilityHintKey: nil,
-                        accessibilityLabelKey: nil,
-                        accessibilityValueKey: nil,
-                        translationKey: \\"Delivery.Widget.Title.COPY\\"
-                    )
-                    static let Title = LocaliciousData(
-                        accessibilityIdentifier: \\"Delivery.Widget.Title\\",
-                        accessibilityHintKey: nil,
-                        accessibilityLabelKey: nil,
-                        accessibilityValueKey: nil,
-                        translationKey: \\"Delivery.Widget.Title.COPY\\"
-                    )
-                    static func SubTitle(quantity: Int) -> LocaliciousData {
-                        let quantityType = LocaliciousQuantity(quanitity: quantity)
-                        return LocaliciousData(
-                        accessibilityIdentifier: \\"Delivery.Widget.SubTitle\\",
-                        accessibilityHintKey: nil,
-                        accessibilityLabelKey: nil,
-                        accessibilityValueKey: nil,
-                        translationKey: \\"Delivery.Widget.SubTitle.COPY.\\\\(quantityType)\\"
-                    )
-                    }
-                    static func SubTitle(quantity: Int) -> LocaliciousData {
-                        let quantityType = LocaliciousQuantity(quanitity: quantity)
-                        return LocaliciousData(
-                        accessibilityIdentifier: \\"Delivery.Widget.SubTitle\\",
-                        accessibilityHintKey: nil,
-                        accessibilityLabelKey: nil,
-                        accessibilityValueKey: nil,
-                        translationKey: \\"Delivery.Widget.SubTitle.COPY.\\\\(quantityType)\\"
-                    )
-                    }
-                    static let SpecialCharacters = LocaliciousData(
-                        accessibilityIdentifier: \\"Delivery.Widget.SpecialCharacters\\",
-                        accessibilityHintKey: nil,
-                        accessibilityLabelKey: nil,
-                        accessibilityValueKey: nil,
-                        translationKey: \\"Delivery.Widget.SpecialCharacters.COPY\\"
-                    )
-                    static let SpecialCharacters = LocaliciousData(
-                        accessibilityIdentifier: \\"Delivery.Widget.SpecialCharacters\\",
-                        accessibilityHintKey: nil,
-                        accessibilityLabelKey: nil,
-                        accessibilityValueKey: nil,
-                        translationKey: \\"Delivery.Widget.SpecialCharacters.COPY\\"
-                    )
-                    static let MultilineStrings = LocaliciousData(
-                        accessibilityIdentifier: \\"Delivery.Widget.MultilineStrings\\",
-                        accessibilityHintKey: nil,
-                        accessibilityLabelKey: nil,
-                        accessibilityValueKey: nil,
-                        translationKey: \\"Delivery.Widget.MultilineStrings.COPY\\"
-                    )
-                    static let MultilineStrings = LocaliciousData(
-                        accessibilityIdentifier: \\"Delivery.Widget.MultilineStrings\\",
-                        accessibilityHintKey: nil,
-                        accessibilityLabelKey: nil,
-                        accessibilityValueKey: nil,
-                        translationKey: \\"Delivery.Widget.MultilineStrings.COPY\\"
-                    )
+        struct Widget {
+            static func Title(args: CVarArg...) -> LocaliciousData {
+                return LocaliciousData(
+                accessibilityIdentifier: \\"Delivery.Widget.Title\\",
+                accessibilityHintKey: nil,
+                accessibilityLabelKey: nil,
+                accessibilityValueKey: nil,
+                translationKey: \\"Delivery.Widget.Title.COPY\\",
+                translationArgs: args
+            )
             }
+            static func Title(args: CVarArg...) -> LocaliciousData {
+                return LocaliciousData(
+                accessibilityIdentifier: \\"Delivery.Widget.Title\\",
+                accessibilityHintKey: nil,
+                accessibilityLabelKey: nil,
+                accessibilityValueKey: nil,
+                translationKey: \\"Delivery.Widget.Title.COPY\\",
+                translationArgs: args
+            )
+            }
+            static func SubTitle(quantity: Int, args: CVarArg...) -> LocaliciousData {
+                let quantityType = LocaliciousQuantity(quanitity: quantity)
+                return LocaliciousData(
+                accessibilityIdentifier: \\"Delivery.Widget.SubTitle\\",
+                accessibilityHintKey: nil,
+                accessibilityLabelKey: nil,
+                accessibilityValueKey: nil,
+                translationKey: \\"Delivery.Widget.SubTitle.COPY.\\\\(quantityType)\\",
+                translationArgs: args
+            )
+            }
+            static func SubTitle(quantity: Int, args: CVarArg...) -> LocaliciousData {
+                let quantityType = LocaliciousQuantity(quanitity: quantity)
+                return LocaliciousData(
+                accessibilityIdentifier: \\"Delivery.Widget.SubTitle\\",
+                accessibilityHintKey: nil,
+                accessibilityLabelKey: nil,
+                accessibilityValueKey: nil,
+                translationKey: \\"Delivery.Widget.SubTitle.COPY.\\\\(quantityType)\\",
+                translationArgs: args
+            )
+            }
+            static let SpecialCharacters = LocaliciousData(
+                accessibilityIdentifier: \\"Delivery.Widget.SpecialCharacters\\",
+                accessibilityHintKey: nil,
+                accessibilityLabelKey: nil,
+                accessibilityValueKey: nil,
+                translationKey: \\"Delivery.Widget.SpecialCharacters.COPY\\",
+                translationArgs: []
+            )
+            static let SpecialCharacters = LocaliciousData(
+                accessibilityIdentifier: \\"Delivery.Widget.SpecialCharacters\\",
+                accessibilityHintKey: nil,
+                accessibilityLabelKey: nil,
+                accessibilityValueKey: nil,
+                translationKey: \\"Delivery.Widget.SpecialCharacters.COPY\\",
+                translationArgs: []
+            )
+            static let MultilineStrings = LocaliciousData(
+                accessibilityIdentifier: \\"Delivery.Widget.MultilineStrings\\",
+                accessibilityHintKey: nil,
+                accessibilityLabelKey: nil,
+                accessibilityValueKey: nil,
+                translationKey: \\"Delivery.Widget.MultilineStrings.COPY\\",
+                translationArgs: []
+            )
+            static let MultilineStrings = LocaliciousData(
+                accessibilityIdentifier: \\"Delivery.Widget.MultilineStrings\\",
+                accessibilityHintKey: nil,
+                accessibilityLabelKey: nil,
+                accessibilityValueKey: nil,
+                translationKey: \\"Delivery.Widget.MultilineStrings.COPY\\",
+                translationArgs: []
+            )
+        }
     }
     struct Accessible {
-            static let RegularComponent = LocaliciousData(
-                accessibilityIdentifier: \\"Accessible.RegularComponent\\",
-                accessibilityHintKey: \\"Accessible.RegularComponent.ACCESSIBILITY.HINT\\",
-                accessibilityLabelKey: \\"Accessible.RegularComponent.ACCESSIBILITY.LABEL\\",
-                accessibilityValueKey: nil,
-                translationKey: \\"Accessible.RegularComponent.COPY\\"
-            )
-            static let RegularComponent = LocaliciousData(
-                accessibilityIdentifier: \\"Accessible.RegularComponent\\",
-                accessibilityHintKey: \\"Accessible.RegularComponent.ACCESSIBILITY.HINT\\",
-                accessibilityLabelKey: \\"Accessible.RegularComponent.ACCESSIBILITY.LABEL\\",
-                accessibilityValueKey: nil,
-                translationKey: \\"Accessible.RegularComponent.COPY\\"
-            )
-            static func PluralComponent(quantity: Int) -> LocaliciousData {
-                let quantityType = LocaliciousQuantity(quanitity: quantity)
-                return LocaliciousData(
-                accessibilityIdentifier: \\"Accessible.PluralComponent\\",
-                accessibilityHintKey: \\"Accessible.PluralComponent.ACCESSIBILITY.HINT.\\\\(quantityType)\\",
-                accessibilityLabelKey: \\"Accessible.PluralComponent.ACCESSIBILITY.LABEL.\\\\(quantityType)\\",
-                accessibilityValueKey: \\"Accessible.PluralComponent.ACCESSIBILITY.VALUE.\\\\(quantityType)\\",
-                translationKey: \\"Accessible.PluralComponent.COPY.\\\\(quantityType)\\"
-            )
-            }
-            static func PluralComponent(quantity: Int) -> LocaliciousData {
-                let quantityType = LocaliciousQuantity(quanitity: quantity)
-                return LocaliciousData(
-                accessibilityIdentifier: \\"Accessible.PluralComponent\\",
-                accessibilityHintKey: \\"Accessible.PluralComponent.ACCESSIBILITY.HINT.\\\\(quantityType)\\",
-                accessibilityLabelKey: \\"Accessible.PluralComponent.ACCESSIBILITY.LABEL.\\\\(quantityType)\\",
-                accessibilityValueKey: \\"Accessible.PluralComponent.ACCESSIBILITY.VALUE.\\\\(quantityType)\\",
-                translationKey: \\"Accessible.PluralComponent.COPY.\\\\(quantityType)\\"
-            )
-            }
+        static let RegularComponent = LocaliciousData(
+            accessibilityIdentifier: \\"Accessible.RegularComponent\\",
+            accessibilityHintKey: \\"Accessible.RegularComponent.ACCESSIBILITY.HINT\\",
+            accessibilityLabelKey: \\"Accessible.RegularComponent.ACCESSIBILITY.LABEL\\",
+            accessibilityValueKey: nil,
+            translationKey: \\"Accessible.RegularComponent.COPY\\",
+            translationArgs: []
+        )
+        static let RegularComponent = LocaliciousData(
+            accessibilityIdentifier: \\"Accessible.RegularComponent\\",
+            accessibilityHintKey: \\"Accessible.RegularComponent.ACCESSIBILITY.HINT\\",
+            accessibilityLabelKey: \\"Accessible.RegularComponent.ACCESSIBILITY.LABEL\\",
+            accessibilityValueKey: nil,
+            translationKey: \\"Accessible.RegularComponent.COPY\\",
+            translationArgs: []
+        )
+        static func PluralComponent(quantity: Int) -> LocaliciousData {
+            let quantityType = LocaliciousQuantity(quanitity: quantity)
+            return LocaliciousData(
+            accessibilityIdentifier: \\"Accessible.PluralComponent\\",
+            accessibilityHintKey: \\"Accessible.PluralComponent.ACCESSIBILITY.HINT.\\\\(quantityType)\\",
+            accessibilityLabelKey: \\"Accessible.PluralComponent.ACCESSIBILITY.LABEL.\\\\(quantityType)\\",
+            accessibilityValueKey: \\"Accessible.PluralComponent.ACCESSIBILITY.VALUE.\\\\(quantityType)\\",
+            translationKey: \\"Accessible.PluralComponent.COPY.\\\\(quantityType)\\",
+            translationArgs: []
+        )
+        }
+        static func PluralComponent(quantity: Int) -> LocaliciousData {
+            let quantityType = LocaliciousQuantity(quanitity: quantity)
+            return LocaliciousData(
+            accessibilityIdentifier: \\"Accessible.PluralComponent\\",
+            accessibilityHintKey: \\"Accessible.PluralComponent.ACCESSIBILITY.HINT.\\\\(quantityType)\\",
+            accessibilityLabelKey: \\"Accessible.PluralComponent.ACCESSIBILITY.LABEL.\\\\(quantityType)\\",
+            accessibilityValueKey: \\"Accessible.PluralComponent.ACCESSIBILITY.VALUE.\\\\(quantityType)\\",
+            translationKey: \\"Accessible.PluralComponent.COPY.\\\\(quantityType)\\",
+            translationArgs: []
+        )
+        }
     }
 }",
       "path": ".//ios/Localizable.swift",

--- a/tests/actions/__snapshots__/render.test.js.snap
+++ b/tests/actions/__snapshots__/render.test.js.snap
@@ -233,7 +233,7 @@ struct L {
                 accessibilityHintKey: nil,
                 accessibilityLabelKey: nil,
                 accessibilityValueKey: nil,
-                translationKey: \\"Delivery.Widget.SubTitle.COPY.\\\\(quantityType)\\",
+                translationKey: \\"Delivery.Widget.SubTitle.COPY.\\\\(quantityType.rawValue)\\",
                 translationArgs: args
             )
             }
@@ -268,10 +268,10 @@ struct L {
             let quantityType = LocaliciousQuantity(quanitity: quantity)
             return LocaliciousData(
             accessibilityIdentifier: \\"Accessible.PluralComponent\\",
-            accessibilityHintKey: \\"Accessible.PluralComponent.ACCESSIBILITY.HINT.\\\\(quantityType)\\",
-            accessibilityLabelKey: \\"Accessible.PluralComponent.ACCESSIBILITY.LABEL.\\\\(quantityType)\\",
-            accessibilityValueKey: \\"Accessible.PluralComponent.ACCESSIBILITY.VALUE.\\\\(quantityType)\\",
-            translationKey: \\"Accessible.PluralComponent.COPY.\\\\(quantityType)\\",
+            accessibilityHintKey: \\"Accessible.PluralComponent.ACCESSIBILITY.HINT.\\\\(quantityType.rawValue)\\",
+            accessibilityLabelKey: \\"Accessible.PluralComponent.ACCESSIBILITY.LABEL.\\\\(quantityType.rawValue)\\",
+            accessibilityValueKey: \\"Accessible.PluralComponent.ACCESSIBILITY.VALUE.\\\\(quantityType.rawValue)\\",
+            translationKey: \\"Accessible.PluralComponent.COPY.\\\\(quantityType.rawValue)\\",
             translationArgs: []
         )
         }
@@ -507,7 +507,7 @@ struct L {
                 accessibilityHintKey: nil,
                 accessibilityLabelKey: nil,
                 accessibilityValueKey: nil,
-                translationKey: \\"Delivery.Widget.SubTitle.COPY.\\\\(quantityType)\\",
+                translationKey: \\"Delivery.Widget.SubTitle.COPY.\\\\(quantityType.rawValue)\\",
                 translationArgs: args
             )
             }
@@ -542,10 +542,10 @@ struct L {
             let quantityType = LocaliciousQuantity(quanitity: quantity)
             return LocaliciousData(
             accessibilityIdentifier: \\"Accessible.PluralComponent\\",
-            accessibilityHintKey: \\"Accessible.PluralComponent.ACCESSIBILITY.HINT.\\\\(quantityType)\\",
-            accessibilityLabelKey: \\"Accessible.PluralComponent.ACCESSIBILITY.LABEL.\\\\(quantityType)\\",
-            accessibilityValueKey: \\"Accessible.PluralComponent.ACCESSIBILITY.VALUE.\\\\(quantityType)\\",
-            translationKey: \\"Accessible.PluralComponent.COPY.\\\\(quantityType)\\",
+            accessibilityHintKey: \\"Accessible.PluralComponent.ACCESSIBILITY.HINT.\\\\(quantityType.rawValue)\\",
+            accessibilityLabelKey: \\"Accessible.PluralComponent.ACCESSIBILITY.LABEL.\\\\(quantityType.rawValue)\\",
+            accessibilityValueKey: \\"Accessible.PluralComponent.ACCESSIBILITY.VALUE.\\\\(quantityType.rawValue)\\",
+            translationKey: \\"Accessible.PluralComponent.COPY.\\\\(quantityType.rawValue)\\",
             translationArgs: []
         )
         }
@@ -913,7 +913,7 @@ struct L {
                 accessibilityHintKey: nil,
                 accessibilityLabelKey: nil,
                 accessibilityValueKey: nil,
-                translationKey: \\"Delivery.Widget.SubTitle.COPY.\\\\(quantityType)\\",
+                translationKey: \\"Delivery.Widget.SubTitle.COPY.\\\\(quantityType.rawValue)\\",
                 translationArgs: args
             )
             }
@@ -924,7 +924,7 @@ struct L {
                 accessibilityHintKey: nil,
                 accessibilityLabelKey: nil,
                 accessibilityValueKey: nil,
-                translationKey: \\"Delivery.Widget.SubTitle.COPY.\\\\(quantityType)\\",
+                translationKey: \\"Delivery.Widget.SubTitle.COPY.\\\\(quantityType.rawValue)\\",
                 translationArgs: args
             )
             }
@@ -983,10 +983,10 @@ struct L {
             let quantityType = LocaliciousQuantity(quanitity: quantity)
             return LocaliciousData(
             accessibilityIdentifier: \\"Accessible.PluralComponent\\",
-            accessibilityHintKey: \\"Accessible.PluralComponent.ACCESSIBILITY.HINT.\\\\(quantityType)\\",
-            accessibilityLabelKey: \\"Accessible.PluralComponent.ACCESSIBILITY.LABEL.\\\\(quantityType)\\",
-            accessibilityValueKey: \\"Accessible.PluralComponent.ACCESSIBILITY.VALUE.\\\\(quantityType)\\",
-            translationKey: \\"Accessible.PluralComponent.COPY.\\\\(quantityType)\\",
+            accessibilityHintKey: \\"Accessible.PluralComponent.ACCESSIBILITY.HINT.\\\\(quantityType.rawValue)\\",
+            accessibilityLabelKey: \\"Accessible.PluralComponent.ACCESSIBILITY.LABEL.\\\\(quantityType.rawValue)\\",
+            accessibilityValueKey: \\"Accessible.PluralComponent.ACCESSIBILITY.VALUE.\\\\(quantityType.rawValue)\\",
+            translationKey: \\"Accessible.PluralComponent.COPY.\\\\(quantityType.rawValue)\\",
             translationArgs: []
         )
         }
@@ -994,10 +994,10 @@ struct L {
             let quantityType = LocaliciousQuantity(quanitity: quantity)
             return LocaliciousData(
             accessibilityIdentifier: \\"Accessible.PluralComponent\\",
-            accessibilityHintKey: \\"Accessible.PluralComponent.ACCESSIBILITY.HINT.\\\\(quantityType)\\",
-            accessibilityLabelKey: \\"Accessible.PluralComponent.ACCESSIBILITY.LABEL.\\\\(quantityType)\\",
-            accessibilityValueKey: \\"Accessible.PluralComponent.ACCESSIBILITY.VALUE.\\\\(quantityType)\\",
-            translationKey: \\"Accessible.PluralComponent.COPY.\\\\(quantityType)\\",
+            accessibilityHintKey: \\"Accessible.PluralComponent.ACCESSIBILITY.HINT.\\\\(quantityType.rawValue)\\",
+            accessibilityLabelKey: \\"Accessible.PluralComponent.ACCESSIBILITY.LABEL.\\\\(quantityType.rawValue)\\",
+            accessibilityValueKey: \\"Accessible.PluralComponent.ACCESSIBILITY.VALUE.\\\\(quantityType.rawValue)\\",
+            translationKey: \\"Accessible.PluralComponent.COPY.\\\\(quantityType.rawValue)\\",
             translationArgs: []
         )
         }
@@ -1277,7 +1277,7 @@ struct L {
                 accessibilityHintKey: nil,
                 accessibilityLabelKey: nil,
                 accessibilityValueKey: nil,
-                translationKey: \\"Delivery.Widget.SubTitle.COPY.\\\\(quantityType)\\",
+                translationKey: \\"Delivery.Widget.SubTitle.COPY.\\\\(quantityType.rawValue)\\",
                 translationArgs: args
             )
             }
@@ -1288,7 +1288,7 @@ struct L {
                 accessibilityHintKey: nil,
                 accessibilityLabelKey: nil,
                 accessibilityValueKey: nil,
-                translationKey: \\"Delivery.Widget.SubTitle.COPY.\\\\(quantityType)\\",
+                translationKey: \\"Delivery.Widget.SubTitle.COPY.\\\\(quantityType.rawValue)\\",
                 translationArgs: args
             )
             }
@@ -1347,10 +1347,10 @@ struct L {
             let quantityType = LocaliciousQuantity(quanitity: quantity)
             return LocaliciousData(
             accessibilityIdentifier: \\"Accessible.PluralComponent\\",
-            accessibilityHintKey: \\"Accessible.PluralComponent.ACCESSIBILITY.HINT.\\\\(quantityType)\\",
-            accessibilityLabelKey: \\"Accessible.PluralComponent.ACCESSIBILITY.LABEL.\\\\(quantityType)\\",
-            accessibilityValueKey: \\"Accessible.PluralComponent.ACCESSIBILITY.VALUE.\\\\(quantityType)\\",
-            translationKey: \\"Accessible.PluralComponent.COPY.\\\\(quantityType)\\",
+            accessibilityHintKey: \\"Accessible.PluralComponent.ACCESSIBILITY.HINT.\\\\(quantityType.rawValue)\\",
+            accessibilityLabelKey: \\"Accessible.PluralComponent.ACCESSIBILITY.LABEL.\\\\(quantityType.rawValue)\\",
+            accessibilityValueKey: \\"Accessible.PluralComponent.ACCESSIBILITY.VALUE.\\\\(quantityType.rawValue)\\",
+            translationKey: \\"Accessible.PluralComponent.COPY.\\\\(quantityType.rawValue)\\",
             translationArgs: []
         )
         }
@@ -1358,10 +1358,10 @@ struct L {
             let quantityType = LocaliciousQuantity(quanitity: quantity)
             return LocaliciousData(
             accessibilityIdentifier: \\"Accessible.PluralComponent\\",
-            accessibilityHintKey: \\"Accessible.PluralComponent.ACCESSIBILITY.HINT.\\\\(quantityType)\\",
-            accessibilityLabelKey: \\"Accessible.PluralComponent.ACCESSIBILITY.LABEL.\\\\(quantityType)\\",
-            accessibilityValueKey: \\"Accessible.PluralComponent.ACCESSIBILITY.VALUE.\\\\(quantityType)\\",
-            translationKey: \\"Accessible.PluralComponent.COPY.\\\\(quantityType)\\",
+            accessibilityHintKey: \\"Accessible.PluralComponent.ACCESSIBILITY.HINT.\\\\(quantityType.rawValue)\\",
+            accessibilityLabelKey: \\"Accessible.PluralComponent.ACCESSIBILITY.LABEL.\\\\(quantityType.rawValue)\\",
+            accessibilityValueKey: \\"Accessible.PluralComponent.ACCESSIBILITY.VALUE.\\\\(quantityType.rawValue)\\",
+            translationKey: \\"Accessible.PluralComponent.COPY.\\\\(quantityType.rawValue)\\",
             translationArgs: []
         )
         }


### PR DESCRIPTION
We now support 4 different leaf nodes based on the requirements for a component:
1. Simple struct properties, for strings without quantity indicator + format:
`static let Component = LocaliciousData(...)`
2. A function that accepts a quantity `Int` to resolve the correct plural (`ZERO`, `ONE`, `OTHER`) string:
`static func Component(quantity: Int) -> LocaliciousData { ... }` 
3. A function that has a variadic args parameter to support formatting in strings:
`static func Component(args: CVarArg...) -> LocaliciousData { ... }` 
4. A combination of (2) and (3)
`static func Component(quantity: Int, args: CVarArg...) -> LocaliciousData { ... }`

Eventually, it would be nice to replace the variadic parameter with the correct amount of params based on the localised string. 