### PR TITLE
Explicitly provide characters to escape for the Android target

### DIFF
--- a/src/actions/render.js
+++ b/src/actions/render.js
@@ -124,10 +124,11 @@ const substitutionsForPlatform = platform => {
         "\n": "\\n",
         "@": "\@", // eslint-disable-line no-useless-escape
         "?": "\?", // eslint-disable-line no-useless-escape
+        // Important: & should be substituted before we introduce new ampersands as part of our substitutions
+        "&": "&amp;",
         "<": "&lt;",
         ">": "&gt;",
-        "&": "&amp;",
-        "\"": "&quot"
+        "\"": "&quot;"
       };
     case platformKeywords.IOS:
       return {

--- a/src/actions/render.js
+++ b/src/actions/render.js
@@ -117,10 +117,17 @@ const codeGenerationFileName = platform => {
 const substitutionsForPlatform = platform => {
   switch (platform) {
     case platformKeywords.ANDROID:
+      // prettier-ignore
       return {
         "{{s}}": "$s",
         "{{d}}": "$d",
-        "\n": "\\n"
+        "\n": "\\n",
+        "@": "\@", // eslint-disable-line no-useless-escape
+        "?": "\?", // eslint-disable-line no-useless-escape
+        "<": "&lt;",
+        ">": "&gt;",
+        "&": "&amp;",
+        "\"": "&quot"
       };
     case platformKeywords.IOS:
       return {

--- a/tests/actions/__snapshots__/normalize.test.js.snap
+++ b/tests/actions/__snapshots__/normalize.test.js.snap
@@ -161,7 +161,7 @@ Array [
   Object {
     "COPY": Object {
       "containsFormatting": false,
-      "translation": "This > is a special <<Character>> & there are more",
+      "translation": "The following characters need special handling on some platforms: @ ? < & ' \\"",
       "type": "SINGULAR",
     },
     "keyPath": Array [
@@ -175,7 +175,7 @@ Array [
   Object {
     "COPY": Object {
       "containsFormatting": false,
-      "translation": "Dit > is een speciaal <<Karakter>> & zo zijn er meer",
+      "translation": "De volgende karakters moeten herschreven worden op sommige platforms: @ ? < & ' \\"",
       "type": "SINGULAR",
     },
     "keyPath": Array [
@@ -576,7 +576,7 @@ Array [
   Object {
     "COPY": Object {
       "containsFormatting": false,
-      "translation": "This > is a special <<Character>> & there are more",
+      "translation": "The following characters need special handling on some platforms: @ ? < & ' \\"",
       "type": "SINGULAR",
     },
     "keyPath": Array [
@@ -590,7 +590,7 @@ Array [
   Object {
     "COPY": Object {
       "containsFormatting": false,
-      "translation": "Dit > is een speciaal <<Karakter>> & zo zijn er meer",
+      "translation": "De volgende karakters moeten herschreven worden op sommige platforms: @ ? < & ' \\"",
       "type": "SINGULAR",
     },
     "keyPath": Array [
@@ -935,7 +935,7 @@ Array [
   Object {
     "COPY": Object {
       "containsFormatting": false,
-      "translation": "This > is a special <<Character>> & there are more",
+      "translation": "The following characters need special handling on some platforms: @ ? < & ' \\"",
       "type": "SINGULAR",
     },
     "keyPath": Array [
@@ -949,7 +949,7 @@ Array [
   Object {
     "COPY": Object {
       "containsFormatting": false,
-      "translation": "Dit > is een speciaal <<Karakter>> & zo zijn er meer",
+      "translation": "De volgende karakters moeten herschreven worden op sommige platforms: @ ? < & ' \\"",
       "type": "SINGULAR",
     },
     "keyPath": Array [

--- a/tests/actions/__snapshots__/render.test.js.snap
+++ b/tests/actions/__snapshots__/render.test.js.snap
@@ -38,8 +38,8 @@ It may also contain empty lines to break up text into paragraphs.\\";
   <string name=\\"Checkout_OrderOverview_Subtotal_COPY\\">\\"Total price before taxes: %1$s\\"</string>
   <string name=\\"Something_With_An_Arbitrary_Amount_Of_Nesting_COPY\\">\\"We support nesting as deep as you'd like\\"</string>
   <string name=\\"Delivery_Widget_Title_COPY\\">\\"Help: %1$s\\"</string>
-  <string name=\\"Delivery_Widget_SpecialCharacters_COPY\\">\\"The following characters need special handling on some platforms: @ ? &amp;lt; &amp; ' &quot\\"</string>
-  <string name=\\"Delivery_Widget_MultilineStrings_COPY\\">\\"This is a multiline string that may contain &amp;lt;a href=&quotabout:blank&quot&amp;gt;links&amp;lt;/a&amp;gt;\\\\nYou better watch out!\\\\n\\\\nIt may also contain empty lines to break up text into paragraphs.\\"</string>
+  <string name=\\"Delivery_Widget_SpecialCharacters_COPY\\">\\"The following characters need special handling on some platforms: @ ? &lt; &amp; ' &quot;\\"</string>
+  <string name=\\"Delivery_Widget_MultilineStrings_COPY\\">\\"This is a multiline string that may contain &lt;a href=&quot;about:blank&quot;&gt;links&lt;/a&gt;\\\\nYou better watch out!\\\\n\\\\nIt may also contain empty lines to break up text into paragraphs.\\"</string>
   <string name=\\"Accessible_RegularComponent_COPY\\">\\"This is a component with accessiblity support\\"</string>
   <string name=\\"Accessible_RegularComponent_ACCESSIBILITY_HINT\\">\\"This is the hint\\"</string>
   <string name=\\"Accessible_RegularComponent_ACCESSIBILITY_LABEL\\">\\"This is the label\\"</string>
@@ -297,8 +297,8 @@ Result {
   <string name=\\"Checkout_OrderOverview_Subtotal_COPY\\">\\"Total price before taxes: %1$s\\"</string>
   <string name=\\"Something_With_An_Arbitrary_Amount_Of_Nesting_COPY\\">\\"We support nesting as deep as you'd like\\"</string>
   <string name=\\"Delivery_Widget_Title_COPY\\">\\"Help: %1$s\\"</string>
-  <string name=\\"Delivery_Widget_SpecialCharacters_COPY\\">\\"The following characters need special handling on some platforms: @ ? &amp;lt; &amp; ' &quot\\"</string>
-  <string name=\\"Delivery_Widget_MultilineStrings_COPY\\">\\"This is a multiline string that may contain &amp;lt;a href=&quotabout:blank&quot&amp;gt;links&amp;lt;/a&amp;gt;\\\\nYou better watch out!\\\\n\\\\nIt may also contain empty lines to break up text into paragraphs.\\"</string>
+  <string name=\\"Delivery_Widget_SpecialCharacters_COPY\\">\\"The following characters need special handling on some platforms: @ ? &lt; &amp; ' &quot;\\"</string>
+  <string name=\\"Delivery_Widget_MultilineStrings_COPY\\">\\"This is a multiline string that may contain &lt;a href=&quot;about:blank&quot;&gt;links&lt;/a&gt;\\\\nYou better watch out!\\\\n\\\\nIt may also contain empty lines to break up text into paragraphs.\\"</string>
   <string name=\\"Accessible_RegularComponent_COPY\\">\\"This is a component with accessiblity support\\"</string>
   <string name=\\"Accessible_RegularComponent_ACCESSIBILITY_HINT\\">\\"This is the hint\\"</string>
   <string name=\\"Accessible_RegularComponent_ACCESSIBILITY_LABEL\\">\\"This is the label\\"</string>
@@ -567,8 +567,8 @@ Result {
   <string name=\\"Checkout_OrderOverview_Subtotal_COPY\\">\\"Total price before taxes: %1$s\\"</string>
   <string name=\\"Something_With_An_Arbitrary_Amount_Of_Nesting_COPY\\">\\"We support nesting as deep as you'd like\\"</string>
   <string name=\\"Delivery_Widget_Title_COPY\\">\\"Help: %1$s\\"</string>
-  <string name=\\"Delivery_Widget_SpecialCharacters_COPY\\">\\"The following characters need special handling on some platforms: @ ? &amp;lt; &amp; ' &quot\\"</string>
-  <string name=\\"Delivery_Widget_MultilineStrings_COPY\\">\\"This is a multiline string that may contain &amp;lt;a href=&quotabout:blank&quot&amp;gt;links&amp;lt;/a&amp;gt;\\\\nYou better watch out!\\\\n\\\\nIt may also contain empty lines to break up text into paragraphs.\\"</string>
+  <string name=\\"Delivery_Widget_SpecialCharacters_COPY\\">\\"The following characters need special handling on some platforms: @ ? &lt; &amp; ' &quot;\\"</string>
+  <string name=\\"Delivery_Widget_MultilineStrings_COPY\\">\\"This is a multiline string that may contain &lt;a href=&quot;about:blank&quot;&gt;links&lt;/a&gt;\\\\nYou better watch out!\\\\n\\\\nIt may also contain empty lines to break up text into paragraphs.\\"</string>
   <string name=\\"Accessible_RegularComponent_COPY\\">\\"This is a component with accessiblity support\\"</string>
   <string name=\\"Accessible_RegularComponent_ACCESSIBILITY_HINT\\">\\"This is the hint\\"</string>
   <string name=\\"Accessible_RegularComponent_ACCESSIBILITY_LABEL\\">\\"This is the label\\"</string>
@@ -633,8 +633,8 @@ It may also contain empty lines to break up text into paragraphs.\\";
   <string name=\\"Checkout_OrderOverview_Subtotal_COPY\\">\\"Subtotaal: %1$s\\"</string>
   <string name=\\"Something_With_An_Arbitrary_Amount_Of_Nesting_COPY\\">\\"Je kan zo veel lagen maken als je zelf wil\\"</string>
   <string name=\\"Delivery_Widget_Title_COPY\\">\\"Help %1$s\\"</string>
-  <string name=\\"Delivery_Widget_SpecialCharacters_COPY\\">\\"De volgende karakters moeten herschreven worden op sommige platforms: @ ? &amp;lt; &amp; ' &quot\\"</string>
-  <string name=\\"Delivery_Widget_MultilineStrings_COPY\\">\\"Dit is een string van meerdere regels die &amp;lt;a href=&quotabout:blank&quot&amp;gt;links&amp;lt;/a&amp;gt; kan bevatten.\\\\nLet maar eens op!\\\\n\\\\nDe tekst kan zelfs witregels bevatten!\\"</string>
+  <string name=\\"Delivery_Widget_SpecialCharacters_COPY\\">\\"De volgende karakters moeten herschreven worden op sommige platforms: @ ? &lt; &amp; ' &quot;\\"</string>
+  <string name=\\"Delivery_Widget_MultilineStrings_COPY\\">\\"Dit is een string van meerdere regels die &lt;a href=&quot;about:blank&quot;&gt;links&lt;/a&gt; kan bevatten.\\\\nLet maar eens op!\\\\n\\\\nDe tekst kan zelfs witregels bevatten!\\"</string>
   <string name=\\"Accessible_RegularComponent_COPY\\">\\"Dit is een component met accessiblity support\\"</string>
   <string name=\\"Accessible_RegularComponent_ACCESSIBILITY_HINT\\">\\"Dit is de hint\\"</string>
   <string name=\\"Accessible_RegularComponent_ACCESSIBILITY_LABEL\\">\\"Dit is de label\\"</string>
@@ -918,8 +918,8 @@ Result {
 <resources>
   <string name=\\"Something_With_An_Arbitrary_Amount_Of_Nesting_COPY\\">\\"We support nesting as deep as you'd like\\"</string>
   <string name=\\"Delivery_Widget_Title_COPY\\">\\"Help: %1$s\\"</string>
-  <string name=\\"Delivery_Widget_SpecialCharacters_COPY\\">\\"The following characters need special handling on some platforms: @ ? &amp;lt; &amp; ' &quot\\"</string>
-  <string name=\\"Delivery_Widget_MultilineStrings_COPY\\">\\"This is a multiline string that may contain &amp;lt;a href=&quotabout:blank&quot&amp;gt;links&amp;lt;/a&amp;gt;\\\\nYou better watch out!\\\\n\\\\nIt may also contain empty lines to break up text into paragraphs.\\"</string>
+  <string name=\\"Delivery_Widget_SpecialCharacters_COPY\\">\\"The following characters need special handling on some platforms: @ ? &lt; &amp; ' &quot;\\"</string>
+  <string name=\\"Delivery_Widget_MultilineStrings_COPY\\">\\"This is a multiline string that may contain &lt;a href=&quot;about:blank&quot;&gt;links&lt;/a&gt;\\\\nYou better watch out!\\\\n\\\\nIt may also contain empty lines to break up text into paragraphs.\\"</string>
   <string name=\\"Accessible_RegularComponent_COPY\\">\\"This is a component with accessiblity support\\"</string>
   <string name=\\"Accessible_RegularComponent_ACCESSIBILITY_HINT\\">\\"This is the hint\\"</string>
   <string name=\\"Accessible_RegularComponent_ACCESSIBILITY_LABEL\\">\\"This is the label\\"</string>
@@ -980,8 +980,8 @@ It may also contain empty lines to break up text into paragraphs.\\";
 <resources>
   <string name=\\"Something_With_An_Arbitrary_Amount_Of_Nesting_COPY\\">\\"Je kan zo veel lagen maken als je zelf wil\\"</string>
   <string name=\\"Delivery_Widget_Title_COPY\\">\\"Help %1$s\\"</string>
-  <string name=\\"Delivery_Widget_SpecialCharacters_COPY\\">\\"De volgende karakters moeten herschreven worden op sommige platforms: @ ? &amp;lt; &amp; ' &quot\\"</string>
-  <string name=\\"Delivery_Widget_MultilineStrings_COPY\\">\\"Dit is een string van meerdere regels die &amp;lt;a href=&quotabout:blank&quot&amp;gt;links&amp;lt;/a&amp;gt; kan bevatten.\\\\nLet maar eens op!\\\\n\\\\nDe tekst kan zelfs witregels bevatten!\\"</string>
+  <string name=\\"Delivery_Widget_SpecialCharacters_COPY\\">\\"De volgende karakters moeten herschreven worden op sommige platforms: @ ? &lt; &amp; ' &quot;\\"</string>
+  <string name=\\"Delivery_Widget_MultilineStrings_COPY\\">\\"Dit is een string van meerdere regels die &lt;a href=&quot;about:blank&quot;&gt;links&lt;/a&gt; kan bevatten.\\\\nLet maar eens op!\\\\n\\\\nDe tekst kan zelfs witregels bevatten!\\"</string>
   <string name=\\"Accessible_RegularComponent_COPY\\">\\"Dit is een component met accessiblity support\\"</string>
   <string name=\\"Accessible_RegularComponent_ACCESSIBILITY_HINT\\">\\"Dit is de hint\\"</string>
   <string name=\\"Accessible_RegularComponent_ACCESSIBILITY_LABEL\\">\\"Dit is de label\\"</string>

--- a/tests/actions/__snapshots__/render.test.js.snap
+++ b/tests/actions/__snapshots__/render.test.js.snap
@@ -8,7 +8,7 @@ Result {
 \\"Settings.PushPermissionsRequest.Subtitle.COPY\\" = \\"Stay up to date\\";
 \\"Something.With.An.Arbitrary.Amount.Of.Nesting.COPY\\" = \\"We support nesting as deep as you'd like\\";
 \\"Delivery.Widget.Title.COPY\\" = \\"Help: %1$@\\";
-\\"Delivery.Widget.SpecialCharacters.COPY\\" = \\"This > is a special <<Character>> & there are more\\";
+\\"Delivery.Widget.SpecialCharacters.COPY\\" = \\"The following characters need special handling on some platforms: @ ? < & ' \\"\\";
 \\"Delivery.Widget.MultilineStrings.COPY\\" = \\"This is a multiline string that may contain <a href=\\"about:blank\\">links</a>
 You better watch out!
 
@@ -38,8 +38,8 @@ It may also contain empty lines to break up text into paragraphs.\\";
   <string name=\\"Checkout_OrderOverview_Subtotal_COPY\\">\\"Total price before taxes: %1$s\\"</string>
   <string name=\\"Something_With_An_Arbitrary_Amount_Of_Nesting_COPY\\">\\"We support nesting as deep as you'd like\\"</string>
   <string name=\\"Delivery_Widget_Title_COPY\\">\\"Help: %1$s\\"</string>
-  <string name=\\"Delivery_Widget_SpecialCharacters_COPY\\">\\"This > is a special <<Character>> & there are more\\"</string>
-  <string name=\\"Delivery_Widget_MultilineStrings_COPY\\">\\"This is a multiline string that may contain <a href=\\"about:blank\\">links</a>\\\\nYou better watch out!\\\\n\\\\nIt may also contain empty lines to break up text into paragraphs.\\"</string>
+  <string name=\\"Delivery_Widget_SpecialCharacters_COPY\\">\\"The following characters need special handling on some platforms: @ ? &amp;lt; &amp; ' &quot\\"</string>
+  <string name=\\"Delivery_Widget_MultilineStrings_COPY\\">\\"This is a multiline string that may contain &amp;lt;a href=&quotabout:blank&quot&amp;gt;links&amp;lt;/a&amp;gt;\\\\nYou better watch out!\\\\n\\\\nIt may also contain empty lines to break up text into paragraphs.\\"</string>
   <string name=\\"Accessible_RegularComponent_COPY\\">\\"This is a component with accessiblity support\\"</string>
   <string name=\\"Accessible_RegularComponent_ACCESSIBILITY_HINT\\">\\"This is the hint\\"</string>
   <string name=\\"Accessible_RegularComponent_ACCESSIBILITY_LABEL\\">\\"This is the label\\"</string>
@@ -297,8 +297,8 @@ Result {
   <string name=\\"Checkout_OrderOverview_Subtotal_COPY\\">\\"Total price before taxes: %1$s\\"</string>
   <string name=\\"Something_With_An_Arbitrary_Amount_Of_Nesting_COPY\\">\\"We support nesting as deep as you'd like\\"</string>
   <string name=\\"Delivery_Widget_Title_COPY\\">\\"Help: %1$s\\"</string>
-  <string name=\\"Delivery_Widget_SpecialCharacters_COPY\\">\\"This > is a special <<Character>> & there are more\\"</string>
-  <string name=\\"Delivery_Widget_MultilineStrings_COPY\\">\\"This is a multiline string that may contain <a href=\\"about:blank\\">links</a>\\\\nYou better watch out!\\\\n\\\\nIt may also contain empty lines to break up text into paragraphs.\\"</string>
+  <string name=\\"Delivery_Widget_SpecialCharacters_COPY\\">\\"The following characters need special handling on some platforms: @ ? &amp;lt; &amp; ' &quot\\"</string>
+  <string name=\\"Delivery_Widget_MultilineStrings_COPY\\">\\"This is a multiline string that may contain &amp;lt;a href=&quotabout:blank&quot&amp;gt;links&amp;lt;/a&amp;gt;\\\\nYou better watch out!\\\\n\\\\nIt may also contain empty lines to break up text into paragraphs.\\"</string>
   <string name=\\"Accessible_RegularComponent_COPY\\">\\"This is a component with accessiblity support\\"</string>
   <string name=\\"Accessible_RegularComponent_ACCESSIBILITY_HINT\\">\\"This is the hint\\"</string>
   <string name=\\"Accessible_RegularComponent_ACCESSIBILITY_LABEL\\">\\"This is the label\\"</string>
@@ -340,7 +340,7 @@ Result {
 \\"Settings.PushPermissionsRequest.Subtitle.COPY\\" = \\"Stay up to date\\";
 \\"Something.With.An.Arbitrary.Amount.Of.Nesting.COPY\\" = \\"We support nesting as deep as you'd like\\";
 \\"Delivery.Widget.Title.COPY\\" = \\"Help: %1$@\\";
-\\"Delivery.Widget.SpecialCharacters.COPY\\" = \\"This > is a special <<Character>> & there are more\\";
+\\"Delivery.Widget.SpecialCharacters.COPY\\" = \\"The following characters need special handling on some platforms: @ ? < & ' \\"\\";
 \\"Delivery.Widget.MultilineStrings.COPY\\" = \\"This is a multiline string that may contain <a href=\\"about:blank\\">links</a>
 You better watch out!
 
@@ -567,8 +567,8 @@ Result {
   <string name=\\"Checkout_OrderOverview_Subtotal_COPY\\">\\"Total price before taxes: %1$s\\"</string>
   <string name=\\"Something_With_An_Arbitrary_Amount_Of_Nesting_COPY\\">\\"We support nesting as deep as you'd like\\"</string>
   <string name=\\"Delivery_Widget_Title_COPY\\">\\"Help: %1$s\\"</string>
-  <string name=\\"Delivery_Widget_SpecialCharacters_COPY\\">\\"This > is a special <<Character>> & there are more\\"</string>
-  <string name=\\"Delivery_Widget_MultilineStrings_COPY\\">\\"This is a multiline string that may contain <a href=\\"about:blank\\">links</a>\\\\nYou better watch out!\\\\n\\\\nIt may also contain empty lines to break up text into paragraphs.\\"</string>
+  <string name=\\"Delivery_Widget_SpecialCharacters_COPY\\">\\"The following characters need special handling on some platforms: @ ? &amp;lt; &amp; ' &quot\\"</string>
+  <string name=\\"Delivery_Widget_MultilineStrings_COPY\\">\\"This is a multiline string that may contain &amp;lt;a href=&quotabout:blank&quot&amp;gt;links&amp;lt;/a&amp;gt;\\\\nYou better watch out!\\\\n\\\\nIt may also contain empty lines to break up text into paragraphs.\\"</string>
   <string name=\\"Accessible_RegularComponent_COPY\\">\\"This is a component with accessiblity support\\"</string>
   <string name=\\"Accessible_RegularComponent_ACCESSIBILITY_HINT\\">\\"This is the hint\\"</string>
   <string name=\\"Accessible_RegularComponent_ACCESSIBILITY_LABEL\\">\\"This is the label\\"</string>
@@ -603,7 +603,7 @@ Result {
 \\"Settings.PushPermissionsRequest.Subtitle.COPY\\" = \\"Stay up to date\\";
 \\"Something.With.An.Arbitrary.Amount.Of.Nesting.COPY\\" = \\"We support nesting as deep as you'd like\\";
 \\"Delivery.Widget.Title.COPY\\" = \\"Help: %1$@\\";
-\\"Delivery.Widget.SpecialCharacters.COPY\\" = \\"This > is a special <<Character>> & there are more\\";
+\\"Delivery.Widget.SpecialCharacters.COPY\\" = \\"The following characters need special handling on some platforms: @ ? < & ' \\"\\";
 \\"Delivery.Widget.MultilineStrings.COPY\\" = \\"This is a multiline string that may contain <a href=\\"about:blank\\">links</a>
 You better watch out!
 
@@ -633,8 +633,8 @@ It may also contain empty lines to break up text into paragraphs.\\";
   <string name=\\"Checkout_OrderOverview_Subtotal_COPY\\">\\"Subtotaal: %1$s\\"</string>
   <string name=\\"Something_With_An_Arbitrary_Amount_Of_Nesting_COPY\\">\\"Je kan zo veel lagen maken als je zelf wil\\"</string>
   <string name=\\"Delivery_Widget_Title_COPY\\">\\"Help %1$s\\"</string>
-  <string name=\\"Delivery_Widget_SpecialCharacters_COPY\\">\\"Dit > is een speciaal <<Karakter>> & zo zijn er meer\\"</string>
-  <string name=\\"Delivery_Widget_MultilineStrings_COPY\\">\\"Dit is een string van meerdere regels die <a href=\\"about:blank\\">links</a> kan bevatten.\\\\nLet maar eens op!\\\\n\\\\nDe tekst kan zelfs witregels bevatten!\\"</string>
+  <string name=\\"Delivery_Widget_SpecialCharacters_COPY\\">\\"De volgende karakters moeten herschreven worden op sommige platforms: @ ? &amp;lt; &amp; ' &quot\\"</string>
+  <string name=\\"Delivery_Widget_MultilineStrings_COPY\\">\\"Dit is een string van meerdere regels die &amp;lt;a href=&quotabout:blank&quot&amp;gt;links&amp;lt;/a&amp;gt; kan bevatten.\\\\nLet maar eens op!\\\\n\\\\nDe tekst kan zelfs witregels bevatten!\\"</string>
   <string name=\\"Accessible_RegularComponent_COPY\\">\\"Dit is een component met accessiblity support\\"</string>
   <string name=\\"Accessible_RegularComponent_ACCESSIBILITY_HINT\\">\\"Dit is de hint\\"</string>
   <string name=\\"Accessible_RegularComponent_ACCESSIBILITY_LABEL\\">\\"Dit is de label\\"</string>
@@ -669,7 +669,7 @@ It may also contain empty lines to break up text into paragraphs.\\";
 \\"Settings.PushPermissionsRequest.Subtitle.COPY\\" = \\"Blijf op de hoogte\\";
 \\"Something.With.An.Arbitrary.Amount.Of.Nesting.COPY\\" = \\"Je kan zo veel lagen maken als je zelf wil\\";
 \\"Delivery.Widget.Title.COPY\\" = \\"Help %1$@\\";
-\\"Delivery.Widget.SpecialCharacters.COPY\\" = \\"Dit > is een speciaal <<Karakter>> & zo zijn er meer\\";
+\\"Delivery.Widget.SpecialCharacters.COPY\\" = \\"De volgende karakters moeten herschreven worden op sommige platforms: @ ? < & ' \\"\\";
 \\"Delivery.Widget.MultilineStrings.COPY\\" = \\"Dit is een string van meerdere regels die <a href=\\"about:blank\\">links</a> kan bevatten.
 Let maar eens op!
 
@@ -918,8 +918,8 @@ Result {
 <resources>
   <string name=\\"Something_With_An_Arbitrary_Amount_Of_Nesting_COPY\\">\\"We support nesting as deep as you'd like\\"</string>
   <string name=\\"Delivery_Widget_Title_COPY\\">\\"Help: %1$s\\"</string>
-  <string name=\\"Delivery_Widget_SpecialCharacters_COPY\\">\\"This > is a special <<Character>> & there are more\\"</string>
-  <string name=\\"Delivery_Widget_MultilineStrings_COPY\\">\\"This is a multiline string that may contain <a href=\\"about:blank\\">links</a>\\\\nYou better watch out!\\\\n\\\\nIt may also contain empty lines to break up text into paragraphs.\\"</string>
+  <string name=\\"Delivery_Widget_SpecialCharacters_COPY\\">\\"The following characters need special handling on some platforms: @ ? &amp;lt; &amp; ' &quot\\"</string>
+  <string name=\\"Delivery_Widget_MultilineStrings_COPY\\">\\"This is a multiline string that may contain &amp;lt;a href=&quotabout:blank&quot&amp;gt;links&amp;lt;/a&amp;gt;\\\\nYou better watch out!\\\\n\\\\nIt may also contain empty lines to break up text into paragraphs.\\"</string>
   <string name=\\"Accessible_RegularComponent_COPY\\">\\"This is a component with accessiblity support\\"</string>
   <string name=\\"Accessible_RegularComponent_ACCESSIBILITY_HINT\\">\\"This is the hint\\"</string>
   <string name=\\"Accessible_RegularComponent_ACCESSIBILITY_LABEL\\">\\"This is the label\\"</string>
@@ -952,7 +952,7 @@ Result {
     Object {
       "data": "\\"Something.With.An.Arbitrary.Amount.Of.Nesting.COPY\\" = \\"We support nesting as deep as you'd like\\";
 \\"Delivery.Widget.Title.COPY\\" = \\"Help: %1$@\\";
-\\"Delivery.Widget.SpecialCharacters.COPY\\" = \\"This > is a special <<Character>> & there are more\\";
+\\"Delivery.Widget.SpecialCharacters.COPY\\" = \\"The following characters need special handling on some platforms: @ ? < & ' \\"\\";
 \\"Delivery.Widget.MultilineStrings.COPY\\" = \\"This is a multiline string that may contain <a href=\\"about:blank\\">links</a>
 You better watch out!
 
@@ -980,8 +980,8 @@ It may also contain empty lines to break up text into paragraphs.\\";
 <resources>
   <string name=\\"Something_With_An_Arbitrary_Amount_Of_Nesting_COPY\\">\\"Je kan zo veel lagen maken als je zelf wil\\"</string>
   <string name=\\"Delivery_Widget_Title_COPY\\">\\"Help %1$s\\"</string>
-  <string name=\\"Delivery_Widget_SpecialCharacters_COPY\\">\\"Dit > is een speciaal <<Karakter>> & zo zijn er meer\\"</string>
-  <string name=\\"Delivery_Widget_MultilineStrings_COPY\\">\\"Dit is een string van meerdere regels die <a href=\\"about:blank\\">links</a> kan bevatten.\\\\nLet maar eens op!\\\\n\\\\nDe tekst kan zelfs witregels bevatten!\\"</string>
+  <string name=\\"Delivery_Widget_SpecialCharacters_COPY\\">\\"De volgende karakters moeten herschreven worden op sommige platforms: @ ? &amp;lt; &amp; ' &quot\\"</string>
+  <string name=\\"Delivery_Widget_MultilineStrings_COPY\\">\\"Dit is een string van meerdere regels die &amp;lt;a href=&quotabout:blank&quot&amp;gt;links&amp;lt;/a&amp;gt; kan bevatten.\\\\nLet maar eens op!\\\\n\\\\nDe tekst kan zelfs witregels bevatten!\\"</string>
   <string name=\\"Accessible_RegularComponent_COPY\\">\\"Dit is een component met accessiblity support\\"</string>
   <string name=\\"Accessible_RegularComponent_ACCESSIBILITY_HINT\\">\\"Dit is de hint\\"</string>
   <string name=\\"Accessible_RegularComponent_ACCESSIBILITY_LABEL\\">\\"Dit is de label\\"</string>
@@ -1014,7 +1014,7 @@ It may also contain empty lines to break up text into paragraphs.\\";
     Object {
       "data": "\\"Something.With.An.Arbitrary.Amount.Of.Nesting.COPY\\" = \\"Je kan zo veel lagen maken als je zelf wil\\";
 \\"Delivery.Widget.Title.COPY\\" = \\"Help %1$@\\";
-\\"Delivery.Widget.SpecialCharacters.COPY\\" = \\"Dit > is een speciaal <<Karakter>> & zo zijn er meer\\";
+\\"Delivery.Widget.SpecialCharacters.COPY\\" = \\"De volgende karakters moeten herschreven worden op sommige platforms: @ ? < & ' \\"\\";
 \\"Delivery.Widget.MultilineStrings.COPY\\" = \\"Dit is een string van meerdere regels die <a href=\\"about:blank\\">links</a> kan bevatten.
 Let maar eens op!
 

--- a/tests/input/localicipe.yaml
+++ b/tests/input/localicipe.yaml
@@ -54,8 +54,8 @@ SHARED:
             nl: '%1{{d}} Lopende bestellingen'
       SpecialCharacters:
         COPY:
-          en: "This > is a special <<Character>> & there are more"
-          nl: "Dit > is een speciaal <<Karakter>> & zo zijn er meer"
+          en: "The following characters need special handling on some platforms: @ ? < & ' \""
+          nl: "De volgende karakters moeten herschreven worden op sommige platforms: @ ? < & ' \""
       MultilineStrings:
         COPY:
           en: |-


### PR DESCRIPTION
The list of characters can be found at https://developer.android.com/guide/topics/resources/string-resource#FormattingAndStyling. Even though not required, I added '>' for symmetry with '<'.

This fixes the follow-up in #24.